### PR TITLE
Built a docker image with all the files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM php:7.4-apache
+
+# Install dependency
+RUN apt-get update && \
+    apt-get install -y zlib1g-dev libpng-dev libjpeg-dev && \
+    docker-php-ext-install pdo_mysql gd mysqli && \
+    a2enmod rewrite && \
+    a2enmod headers && \
+    a2enmod expires
+
+# Copy application files to a different folder
+COPY . /var/www/container_files/ 
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh 
+
+RUN chmod +x /entrypoint.sh && \
+    chown -R www-data:www-data /var/www/container_files/ && \
+    chmod -R 755 /var/www/container_files/
+
+EXPOSE 80
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh && \
     chown -R www-data:www-data /var/www/container_files/ && \
-    chmod -R 755 /var/www/container_files/
+    chmod -R 777 /var/www/container_files/
 
 EXPOSE 80
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  web:
+    build: .
+    container_name: travianz
+    ports:
+      - "8080:80"
+    volumes:
+      - ./html:/var/www/html
+    restart: always
+
+  db:
+    container_name: MySQL_database
+    image: mysql
+    ports:
+      - "3306:3306"
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: RootPassword
+    volumes:
+      - ./db:/var/lib/mysql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,21 +2,23 @@ version: '3.8'
 
 services:
   web:
-    build: .
+    build: . # this will build the image using Dockerfile and the files in the same dir
+    # image: unclechuen/travianz:latest # this image is built using Dockerfile along with the whole repository
     container_name: travianz
     ports:
-      - "8080:80"
+      - "80:80"
     volumes:
       - ./html:/var/www/html
     restart: always
 
   db:
-    container_name: MySQL_database
+    container_name: MySQL
     image: mysql
     ports:
       - "3306:3306"
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: RootPassword
+      MYSQL_DATABASE: travian
     volumes:
       - ./db:/var/lib/mysql

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,8 @@ else
     cp -R /var/www/container_files/* /var/www/html/
 fi
 
+chown -R www-data:www-data /var/www/html
+chmod -R 777 /var/www/html
+
 # Start the Apache server in the foreground
 exec apache2-foreground

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Check if the local folder is empty
+if [ "$(ls -A /var/www/html)" ]; then
+    echo "Local folder is not empty. Skipping file copy."
+else
+    echo "Local folder is empty. Copying files from container."
+    cp -R /var/www/container_files/* /var/www/html/
+fi
+
+# Start the Apache server in the foreground
+exec apache2-foreground


### PR DESCRIPTION
I made a docker image for the whole repository, pack everything into the PHP docker base image, and install all required dependencies.

It is effortless to spin up the DB and the PHP server within one command by either build the docker image locally, or using the docker-compose scripts.

## Usage example

### Build a local docker image (using the Dockerfile)
```
docker build .
```

### Start the game db and PHP server (using the docker-compose.yaml)
In the docker-compose.yaml, you can either 
1. Build locally (build: .), or 
2. Pull the image that I built (unclechuen/travianz:latest) from docker hub

Comment out either one of them, then open terminal, navigate to any folder you want, and run the following command.
```
docker-compose up -d
```

In that dir, 2 folders will be created automatically. 
- ./db/  is the data for MySQL server. The db password can be modified at the docekr-compose.yaml
- ./html/ is the game file folder. Upon the execution of docker-compose script, all the files (from this repo) will be copied to the folder. It is linked to the game image by using volume binding. You can modify or backup those files.


One odd thing I have found is that the "localhost" value for the database connection may not work, as each container is further divided into individual env. May need to use the IP address of the host machine to make it work.

