### PR TITLE
Add missing escape chars, fixing Q25_27 (Task 23: Friends.)

### DIFF
--- a/GameEngine/Lang/en.php
+++ b/GameEngine/Lang/en.php
@@ -197,7 +197,7 @@ define('EASTER', 'Happy Easter');
 define('PEACE', 'Peace');
 
 define('GOLD', 'Gold');
-define('GOLD_IMG', '<img src="/img/x.gif" class="gold" alt="'.GOLD.'" title="'.GOLD.'">');
+define('GOLD_IMG', '<img src=\"/img/x.gif\" class=\"gold\" alt=\"'.GOLD.'\" title=\"'.GOLD.'\">');
 
 //QUEST
 define('Q_CONTINUE', 'Continue with the next task.');

--- a/GameEngine/Lang/zh_tw.php
+++ b/GameEngine/Lang/zh_tw.php
@@ -197,7 +197,7 @@ define('EASTER', 'Happy Easter');
 define('PEACE', 'Peace');
 
 define('GOLD', '金币');
-define('GOLD_IMG', '<img src="/img/x.gif" class="gold" alt="'.GOLD.'" title="'.GOLD.'">');
+define('GOLD_IMG', '<img src=\"/img/x.gif\" class=\"gold\" alt=\"'.GOLD.'\" title=\"'.GOLD.'\">');
 
 //QUEST
 define('Q_CONTINUE', '继续下一个任务。');


### PR DESCRIPTION
Task 23: Friends was not loading due to a JSON parsing error caused by the `GOLD_IMG` constant containing unescaped HTML.

![1](https://github.com/user-attachments/assets/f25053b3-477b-4683-824e-1e8a0cd2eb39)

![3](https://github.com/user-attachments/assets/42be5fc6-654f-49cd-b98c-875ea33513d8)

![4](https://github.com/user-attachments/assets/22f6aab4-0c33-44f8-9b83-076555569a87)
![5](https://github.com/user-attachments/assets/2ff7d93f-42eb-479a-8336-ecd03e2b1aa7)

Fixed by adding escape chars:

![image](https://github.com/user-attachments/assets/fe7ce24b-5938-4874-b0dd-8f7f9bddaff5)

![image](https://github.com/user-attachments/assets/f77407fc-98af-4419-8b7b-72bb485c94af)

