### PR TITLE
Fix WW build task cancelled after Natar attack with 0 damage (issue #67)

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -722,8 +722,10 @@ class Automation {
             
             $newLevel = $battle->calculateNewBuildingLevel($tblevel, $catapultsDamage / ($twoRowsCatapultSetup ? 2 : 1));
 
-            //If that building was present in the building queue, we have to modify his level or remove it
-            $database->modifyBData($data['to'], $tbid, [$newLevel, $tblevel], $tribe);
+            //fix: Only modify build queue if actual damage was dealt
+			if ($newLevel < $tblevel) {
+				$database->modifyBData($data['to'], $tbid, [$newLevel, $tblevel], $tribe);
+			}
             
             // building/field destroyed
             if ($newLevel == 0){       


### PR DESCRIPTION
fix for issue #67
When Natars attack a WW village and fail to damage it, the in-progress WW building task is still cancelled from the build queue. In resolveCatapultsDestruction(), the function modifyBData() is called unconditionally, before any check on whether the building was actually damaged. Fix prevents the unnecessary call.