### PR TITLE
Fix infinite gold hack in extended quest

### DIFF
--- a/Templates/Ajax/quest_core.tpl
+++ b/Templates/Ajax/quest_core.tpl
@@ -65,6 +65,7 @@ if (isset($qact)){
 			//Get reward: Resources: Every 24 hours (1 speed)  24/speed=hours
 			//Gold: 25 gold
 		case 'skip':
+			if ($check_quest != 0) break;
 			$database->updateUserField($_SESSION['username'],'quest','90',0);
 			$_SESSION['qst']= 90;
 			break;


### PR DESCRIPTION
In extended quests, there is a possibility to go back in quests by abusing "skip" and by running two links generating infinite amount of gold. Skip is meant to be used only once, so I added a simple check if any quest was already done, if yes, it will not allow skipping anymore. Fixes #135.