### PR TITLE
Fix hero mansion level 0 exposed elements

### DIFF
--- a/Templates/Build/37.tpl
+++ b/Templates/Build/37.tpl
@@ -62,9 +62,9 @@
             $name1 = 'unknown';
         }
 
-		if(isset($_GET['land'])) {
+		if(isset($_GET['land']) && $village->resarray['f' . $id] >= 1) {
             include_once("37_land.tpl");
-		} else {
+		} else if ($village->resarray['f' . $id] >= 1) {
             $include_training = true;
             $include_revive = false;
             if (isset($heroes) && is_array($heroes) && count($heroes)) {


### PR DESCRIPTION
When you are building new hero's mansion (lvl0 > lvl1) the UI is already exposed and allows you to train/revive hero or manage oasis. That is obviously wrong. Fix is checking the level of this building and only shows you these options when level is at least 1.