### PR TITLE
Fix: Restrict village spawn search to selected quadrant

### DIFF
--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -1384,9 +1384,6 @@ public function getBestOasisCropBonus($x, $y) {
             $numberOfVillages -= $resultedRows;
             $count++;
             
-            //If there are no more free cells in that sector, it have to be changed
-            //This instruction will be used only (in the next cicle(s)) if not all wids have been generated yet
-            if ($count > intval(WORLD_MAX / 10)) $sector = rand(1, 4);
         }
 
         foreach($villages as $village) $wids[] = $village['id'];


### PR DESCRIPTION
Fixes #127
From what I can see the line was a workaround for a problem that Shadowss own fix already solved, but it was left behind and now causes the bug. solution is to delete this line because subsequent code already handles the situation.
This actually affects any quadrant, not just NE as was mentioned in issue.