### PR TITLE
Fix HTTP 500 when queuing a 2nd Smithy/Armoury upgrade of the same unit

### DIFF
--- a/var/db/struct.sql
+++ b/var/db/struct.sql
@@ -1292,8 +1292,11 @@ CREATE TABLE IF NOT EXISTS `%PREFIX%research` (
  `timestamp` int(11) NULL,
  PRIMARY KEY (`id`),
  KEY `vref` (`vref`),
- KEY `timestamp` (`timestamp`),
-  UNIQUE KEY `vref_tech` (`vref`,`tech`)
+ KEY `timestamp` (`timestamp`)
+ -- NOTE: no UNIQUE(vref,tech) here on purpose. The Smithy/Armoury queue stores
+ -- each queued upgrade of the SAME unit as its own row (same tech, different
+ -- timestamp). A UNIQUE(vref,tech) made the 2nd queued upgrade INSERT fail,
+ -- which under PHP 8 mysqli (exceptions on) became an uncaught HTTP 500.
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --


### PR DESCRIPTION
The research table had UNIQUE KEY (vref, tech). The Smithy/Armoury queue (Technology::upgradeSword/upgradeArmour) lets a player stack a 2nd upgrade of the SAME unit (with Plus), stored as a second research row with the same tech but a later timestamp. That 2nd INSERT violated the unique key; under PHP 8 mysqli (exceptions on by default) the duplicate-key error became an uncaught mysqli_sql_exception -> HTTP 500 (resources already deducted).

Confirmed in production:
  Uncaught mysqli_sql_exception: Duplicate entry '81233-b2' for key
  'vref_tech' in Database.php:6215 (addResearch) <- upgradeSword

Drop UNIQUE(vref, tech): the queue legitimately needs multiple rows per tech, and researchComplete() does `tech = tech + 1` per row, so two 'b2' rows correctly yield +2. Nothing relies on the unique key.

Existing databases must also drop the index:
  ALTER TABLE `<prefix>research` DROP INDEX `vref_tech`;