### PR TITLE
Refactor/sendunitscomplete extract

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -891,6 +891,39 @@ class Automation {
     }
 
     /**
+     * Fetch all attacks (sort_type 3, not reinforcement) that have arrived by
+     * $time, joined with their attack rows, ordered by arrival.
+     * Pure behaviour-preserving extraction (refactor for issue #155).
+     *
+     * @param int $time Current timestamp.
+     * @return array Rows of pending/completed attacks.
+     */
+    private function fetchCompletedAttacks($time) {
+        global $database;
+
+        $time = (int) $time;
+        $q = "
+            SELECT
+                `from`, `to`, endtime, ref, ctar1, ctar2, spy, moveid, attack_type,
+                t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, (SELECT oasistype FROM ".TB_PREFIX."wdata WHERE id = `to`) as oasistype
+            FROM
+                ".TB_PREFIX."movement,
+                ".TB_PREFIX."attacks
+            WHERE
+                ".TB_PREFIX."movement.ref = ".TB_PREFIX."attacks.id
+                AND
+                ".TB_PREFIX."movement.proc = 0
+                AND
+                ".TB_PREFIX."movement.sort_type = 3
+                AND
+                ".TB_PREFIX."attacks.attack_type != 2
+                AND
+                endtime < $time
+            ORDER BY endtime ASC";
+        return $database->query_return($q);
+    }
+
+    /**
      * Batch-preload the village / unit / tech data used by sendunitsComplete()
      * so the per-attack loop hits the in-request cache instead of querying row
      * by row. Pure behaviour-preserving extraction (refactor for issue #155).
@@ -921,25 +954,7 @@ class Automation {
         global $bid19, $bid23, $bid34, $u99, $database, $battle, $technology, $units;
 
         $time = time();
-        $q = "
-            SELECT
-                `from`, `to`, endtime, ref, ctar1, ctar2, spy, moveid, attack_type,
-                t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, (SELECT oasistype FROM ".TB_PREFIX."wdata WHERE id = `to`) as oasistype
-            FROM
-                ".TB_PREFIX."movement,
-                ".TB_PREFIX."attacks
-            WHERE
-                ".TB_PREFIX."movement.ref = ".TB_PREFIX."attacks.id
-                AND
-                ".TB_PREFIX."movement.proc = 0
-                AND
-                ".TB_PREFIX."movement.sort_type = 3
-                AND
-                ".TB_PREFIX."attacks.attack_type != 2
-                AND
-                endtime < $time
-            ORDER BY endtime ASC";
-        $dataarray = $database->query_return($q);
+        $dataarray = $this->fetchCompletedAttacks($time);
         $totalattackdead = $data_num = 0;
 
         if ($dataarray && count($dataarray)) {

--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -890,6 +890,30 @@ class Automation {
         return (mysqli_affected_rows($database->dblink) === 1);
     }
 
+    /**
+     * Batch-preload the village / unit / tech data used by sendunitsComplete()
+     * so the per-attack loop hits the in-request cache instead of querying row
+     * by row. Pure behaviour-preserving extraction (refactor for issue #155).
+     *
+     * @param array $dataarray Completed attacks (each with 'from' and 'to').
+     */
+    private function preloadBattleData(array $dataarray) {
+        global $database;
+
+        $vilIDs = [];
+        foreach ($dataarray as $data) {
+            $vilIDs[$data['from']] = true;
+            $vilIDs[$data['to']] = true;
+        }
+        $vilIDs = array_keys($vilIDs);
+
+        $database->getProfileVillages($vilIDs, 5);
+        $database->getUnit($vilIDs);
+        $database->getEnforceVillage($vilIDs, 0);
+        $database->getMovement(34, $vilIDs, 1);
+        $database->getABTech($vilIDs);
+    }
+
     private function sendunitsComplete() {
         // PROCESARE ATACURI COMPLETE - functie critica, pastrata 100% compatibila
         // Aceasta functie gestioneaza toate atacurile care ajung la destinatie
@@ -919,18 +943,9 @@ class Automation {
         $totalattackdead = $data_num = 0;
 
         if ($dataarray && count($dataarray)) {
-            // preload village data
-            $vilIDs = [];
-            foreach($dataarray as $data) {
-                $vilIDs[$data['from']] = true;
-                $vilIDs[$data['to']] = true;
-            }
-            $vilIDs = array_keys($vilIDs);
-            $database->getProfileVillages($vilIDs, 5);
-            $database->getUnit($vilIDs);
-            $database->getEnforceVillage($vilIDs, 0);
-            $database->getMovement(34, $vilIDs, 1);
-            $database->getABTech($vilIDs);
+            // preload village data (batched) so the per-attack loop hits the
+            // cache instead of querying row by row
+            $this->preloadBattleData($dataarray);
 
             // calculate battles
             foreach($dataarray as $data) {


### PR DESCRIPTION
TITRE :
Refactor sendunitsComplete() – part 1: extract data fetch & preload (#155)

DESCRIPTION :
Re #155. First, **behaviour-preserving** step toward refactoring the ~1730-line `sendunitsComplete()` combat resolver. No combat logic is touched — this only extracts two self-contained blocks from the top of the function into private helpers.

## Changes
- `fetchCompletedAttacks($time)` — the SELECT that fetches arrived attacks (joined with `attacks`), ordered by arrival. Input `$time`, returns the rows.
- `preloadBattleData($dataarray)` — the batched pre-load (`getProfileVillages` / `getUnit` / `getEnforceVillage` / `getMovement` / `getABTech`). `$vilIDs` was local to this block and unused afterwards.

Both are pure extractions: same code, same order, no dynamic variables involved, nothing reused downstream.

## Why
`sendunitsComplete()` is one big function and hard to optimise safely. Splitting out the clean, low-risk pieces first makes the hot loop readable and sets the stage for the performance work in phase A (the per-attack loop currently repeats DB lookups that the pre-load already cached).

## Scope / safety
- Combat math, catapults, conquest, evasion, reports: **untouched**.
- `php -l` passes (PHP 8.3).
- Verified a real battle produces the same result.

This is intentionally a small, easy-to-review slice. Further extractions (the battle body) will come as separate PRs, since they involve converting the `${'dead'.$i}` / `${'traped'.$i}` dynamic variables to arrays and need battle testing (the function uses `rand()`).