### PR TITLE
Refactor(sendunitsComplete): extract applyBounty() [#155]

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -1228,6 +1228,63 @@ class Automation {
         $database->getABTech($vilIDs);
     }
 
+    /**
+     * Distribute the battle bounty across the resources actually available in
+     * the target (after cranny protection) and return how much of each is taken.
+     * Pure behaviour-preserving extraction (refactor for issue #155).
+     *
+     * @param array $available [wood, clay, iron, crop] lootable amounts.
+     * @param int   $bounty    Total carry capacity / bounty from the battle.
+     * @return array [wood, clay, iron, crop] amounts actually stolen.
+     */
+    private function applyBounty(array $available, $bounty) {
+        $avtotal = $available;
+        $steal   = [0, 0, 0, 0];
+        $btotal  = $bounty;
+        $bmod    = 0;
+
+        for ($i = 0; $i < 5; $i++) {
+            for ($j = 0; $j < 4; $j++) {
+                if (isset($avtotal[$j])) {
+                    if ($avtotal[$j] < 1) unset($avtotal[$j]);
+                }
+            }
+
+            // No resources left to take
+            if (empty($avtotal) || ($btotal < 1 && $bmod < 1)) break;
+
+            if ($btotal < 1) {
+                while ($bmod) {
+                    // random select
+                    $rs = array_rand($avtotal);
+                    if (isset($avtotal[$rs])) {
+                        $avtotal[$rs] -= 1;
+                        $steal[$rs]   += 1;
+                        $bmod         -= 1;
+                    }
+                }
+            }
+
+            // handle unbalanced amounts.
+            $btotal += $bmod;
+            $bmod    = $btotal % count($avtotal);
+            $btotal -= $bmod;
+            $bsplit  = $btotal / count($avtotal);
+
+            $max_steal = (min($avtotal) < $bsplit) ? min($avtotal) : $bsplit;
+
+            for ($j = 0; $j < 4; $j++) {
+                if (isset($avtotal[$j])) {
+                    $avtotal[$j] -= $max_steal;
+                    $steal[$j]   += $max_steal;
+                    $btotal      -= $max_steal;
+                }
+            }
+        }
+
+        return $steal;
+    }
+
     private function sendunitsComplete() {
         // PROCESARE ATACURI COMPLETE - functie critica, pastrata 100% compatibila
         // Aceasta functie gestioneaza toate atacurile care ajung la destinatie
@@ -2189,62 +2246,8 @@ class Automation {
                     $avwood = ($avwood < 0) ? 0 : $avwood;
                     $avcrop = ($avcrop < 0) ? 0 : $avcrop;
 
-                    $avtotal = [$avwood, $avclay, $aviron, $avcrop];
-                    $av = $avtotal;
-
-                    // resources (wood,clay,iron,crop)
-                    $steal = [0, 0, 0, 0];
-
-                    //bounty variables
-                    $btotal = $battlepart['bounty'];
-                    $bmod = 0;
-
-                    for($i = 0; $i < 5; $i++)
-                    {
-                        for($j = 0; $j < 4; $j++)
-                        {
-                            if(isset($avtotal[$j]))
-                            {
-                                if($avtotal[$j] < 1) unset($avtotal[$j]);                           
-                            }
-                        }
-
-                        //No resources left to take
-                        if(empty($avtotal) || ($btotal < 1 && $bmod < 1)) break;
-                        
-                        if($btotal < 1)
-                        {
-                            while($bmod)
-                            {
-                                //random select
-                                $rs = array_rand($avtotal);
-                                if(isset($avtotal[$rs]))
-                                {
-                                    $avtotal[$rs] -= 1;
-                                    $steal[$rs] += 1;
-                                    $bmod -= 1;
-                                }
-                            }
-                        }
-
-                        // handle unbalanced amounts.
-                        $btotal += $bmod;
-                        $bmod = $btotal % count($avtotal);
-                        $btotal -= $bmod;
-                        $bsplit = $btotal / count($avtotal);
-                        
-                        $max_steal = (min($avtotal) < $bsplit) ? min($avtotal) : $bsplit;
-                        
-                        for($j = 0; $j < 4; $j++)
-                        {
-                            if(isset($avtotal[$j]))
-                            {
-                                $avtotal[$j] -= $max_steal;
-                                $steal[$j] += $max_steal;
-                                $btotal -= $max_steal;
-                            }
-                        }
-                    }                    
+                    // bounty distributed across the resources available after cranny protection (extracted to applyBounty() [#155])
+                    $steal = $this->applyBounty([$avwood, $avclay, $aviron, $avcrop], $battlepart['bounty']);
 
                     //chiefing village — extracted to handleConquest() [#155]
                     if (!isset($village_destroyed)) $village_destroyed = 0;


### PR DESCRIPTION
Continues the Phase B refactor of `sendunitsComplete()` (issue #155), one
isolated extraction at a time. Follows #176 and #177.

## What this does

Extracts the bounty-distribution loop (~56 lines) into `applyBounty()`, a pure
behaviour-preserving change:

- **`applyBounty(array $available, $bounty): array`** spreads the battle bounty
  across the resources still available in the target after cranny protection,
  and returns the `[wood, clay, iron, crop]` amounts stolen (including the
  `array_rand()` remainder distribution, unchanged).

The call site in `sendunitsComplete()` is now a one-liner. The dead
`$av = $avtotal` assignment (assigned, never read) is dropped; no other variable
from the block is used downstream.

## How it was validated

Deterministic A/B harness (replays the same battle on `master` vs this branch
and diffs the persisted, production-independent outcome). All scenarios
**IDENTICAL** (self-check passes first, proving determinism):

1. **Common attack** — no-loot path (early return), no regression.
2. **Evasion** — `handleEvasion()` still fine.
3. **Conquest** — `handleConquest()` still fine (conquest confirmed to fire).
4. **Loot** — defender given a large stock so the distribution loop actually
   runs: the full bounty (30000) is split evenly (7500 per resource) identically
   on both sides. This exercises the core of `applyBounty()`.

## Next extractions (separate PRs)

`buildReports()`, then the trickier `applyCatapults()` (it recalculates the
battle when the wall is damaged), before Phase A (perf).