### PR TITLE
Fix fatal parse error in Automation.php (broken #180/#181 merge)

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -1257,6 +1257,8 @@ class Automation {
                             else $info_spy = "".$spy_pic.", There are no informations to show";                                                   
                         }
         return $info_spy;
+    }
+
     /**
      * Distribute the battle bounty across the resources actually available in
      * the target (after cranny protection) and return how much of each is taken.


### PR DESCRIPTION
The merge of #180 (applyBounty) and #181 (buildScoutReport) dropped the closing
brace of `buildScoutReport()` — both PRs inserted a new method just before
`sendunitsComplete()`, and the merge resolution lost the `}`. As a result
`applyBounty()` is declared inside `buildScoutReport()`:

    PHP Parse error: syntax error, unexpected token "private"
    in GameEngine/Automation.php

This makes `Automation.php` return HTTP 500, so the whole automation stops:
troop movements never resolve, buildings never complete, etc. Current `master`
is affected for everyone.

Fix: restore the missing `}` closing `buildScoutReport()`. Brace balance is even
again (634/634). One-line structural fix, no logic change.