### PR TITLE
security: harden signup username validation + fix reflected XSS (#184)

### DIFF
--- a/GameEngine/Account.php
+++ b/GameEngine/Account.php
@@ -77,9 +77,17 @@ class Account {
     } else {
         if (strlen($_POST['name']) < USRNM_MIN_LENGTH) {
             $form->addError("name", USRNM_SHORT);
+        } elseif (strlen($_POST['name']) > (defined('USRNM_MAX_LENGTH') ? USRNM_MAX_LENGTH : 15)) {
+            // Hard upper bound on the username length (issue #184).
+            $form->addError("name", USRNM_CHAR);
         } elseif (!USRNM_SPECIAL && preg_match('/[^0-9A-Za-z]/', $_POST['name'])) {
             $form->addError("name", USRNM_CHAR);
-        } elseif (USRNM_SPECIAL && preg_match("/[:,\\. \\n\\r\\t\\s\\<\\>]+/", $_POST['name'])) {
+        } elseif (USRNM_SPECIAL && !preg_match('/^[A-Za-z0-9._-]+(?: [A-Za-z0-9._-]+)*$/D', $_POST['name'])) {
+            // SECURITY (issue #184): positive ASCII allowlist instead of the old
+            // negative filter. Allows letters, digits, . _ - and single internal
+            // spaces only (no leading/trailing/double spaces, no trailing newline).
+            // Blocks & = ' " < > ; ( ) and ALL multibyte/emoji input, which were
+            // previously accepted and led to stored XSS / display corruption.
             $form->addError("name", USRNM_CHAR);
         } elseif (strtolower($_POST['name']) === 'natars') {
             $form->addError("name", USRNM_TAKEN);

--- a/anmelden.php
+++ b/anmelden.php
@@ -61,28 +61,28 @@ if(REG_OPEN == true){ ?>
 <p><?php echo BEFORE_REGISTER; ?></p>
 
 <form name="snd" method="post" action="anmelden.php">
-<input type="hidden" name="invited" value="<?php echo $invited; ?>" />
+<input type="hidden" name="invited" value="<?php echo htmlspecialchars($invited, ENT_QUOTES, 'UTF-8'); ?>" />
 <input type="hidden" name="ft" value="a1" />
 
 <table cellpadding="1" cellspacing="1" id="sign_input">
 	<tbody>
 		<tr class="top">
 			<th><?php echo NICKNAME; ?></th>
-			<td><input class="text" type="text" name="name" value="<?php echo $form->getValue('name'); ?>" maxlength="30" />
+			<td><input class="text" type="text" name="name" value="<?php echo htmlspecialchars($form->getValue('name'), ENT_QUOTES, 'UTF-8'); ?>" maxlength="30" />
 			<span class="error"><?php echo $form->getError('name'); ?></span>
 			</td>
 		</tr>
 		<tr>
 			<th><?php echo EMAIL; ?></th>
 			<td>
-				<input class="text" type="text" name="email" value="<?php echo stripslashes($form->getValue('email')); ?>" />
+				<input class="text" type="text" name="email" value="<?php echo htmlspecialchars(stripslashes($form->getValue('email')), ENT_QUOTES, 'UTF-8'); ?>" />
 				<span class="error"><?php echo $form->getError('email'); ?></span>
 				</td>
 			</tr>
 		<tr>
 			<th><?php echo PASSWORD; ?></th>
 			<td>
-				<input class="text" type="password" name="pw" value="<?php echo stripslashes($form->getValue('pw')); ?>" maxlength="100" />
+				<input class="text" type="password" name="pw" value="<?php echo htmlspecialchars(stripslashes($form->getValue('pw')), ENT_QUOTES, 'UTF-8'); ?>" maxlength="100" />
 				<span class="error"><?php echo $form->getError('pw'); ?></span>
 			</td>
 		</tr>

--- a/login.php
+++ b/login.php
@@ -193,7 +193,7 @@ Element.implement({
 		</tr>
 		<tr class="btm">
 			<th><?php echo PASSWORD; ?></th>
-			<td><input class="text" type="password" name="pw" value="<?php echo $form->getValue("pw");?>" maxlength="100" autocomplete='off' /> <span class="error"><?php echo $form->getError("pw"); ?></span></td>
+			<td><input class="text" type="password" name="pw" value="<?php echo htmlspecialchars($form->getValue("pw"), ENT_QUOTES, 'UTF-8');?>" maxlength="100" autocomplete='off' /> <span class="error"><?php echo $form->getError("pw"); ?></span></td>
 		</tr>
 	</tbody>
 </table>
@@ -217,7 +217,7 @@ if($form->getError("activate") != "") {
 	echo "<p class=\"error_box\">
 	<span class=\"error\">".EMAIL_NOT_VERIFIED."</span><br>
 	".EMAIL_FOLLOW."<br>
-	<a href=\"activate.php?usr=".$form->getError("activate")."\">".VERIFY_EMAIL."</a>
+	<a href=\"activate.php?usr=".urlencode($form->getError("activate"))."\">".VERIFY_EMAIL."</a>
 	</p>";
 }
 if($form->getError("vacation") != "") {


### PR DESCRIPTION
Fixes #184.

## Diagnosis
The screenshots in the issue show usernames like `ft=p1&mw=1&ort=London&jahr=200`
and emoji/multibyte strings (`👉 CLICK`) being created at signup. Root cause:
`Account::Signup()` used a permissive **negative** filter that only blocked
`: , . space < >`, letting `& = ' " ; ( )` and all multibyte input through, with
**no maximum length**. The registration form also echoed the submitted value back
**unescaped**, allowing reflected/stored XSS. The DB writes themselves were already
prepared statements, so this closes the input side that the report exercised.

## Changes
- **Account.php**: replaced the negative filter with a positive ASCII allowlist
  (letters, digits, `. _ -` and single internal spaces), rejecting
  leading/trailing/double spaces and trailing newline (`/D`), plus a maximum length
  (`USRNM_MAX_LENGTH`, default 15).
- **anmelden.php**: `htmlspecialchars()` on the repopulated name/email/pw and the
  hidden `invited` value.
- **login.php**: `htmlspecialchars()` on the repopulated password, `urlencode()` on
  the `activate` username reflected into an href (same XSS class).

## Notes
- No SQL/schema changes. PHP 8.3, `php -l` clean.
- Tested on my own server: tried registering with the payloads from the issue
  (`&`, `=`, quotes, emoji, over-length) — all now rejected, and normal names still
  work. Could you also test on your side to be safe?

## Coming next
I'll propose an **additional brute-force protection** layer (login throttling /
failed-attempt limiting) in a **separate PR**, complementing this input-hardening
and the IP-ban work (#185).