### PR TITLE
feat: reports for settling — new village founded & valley occupied (#178)

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -2990,6 +2990,10 @@ class Automation {
 				}
 				
 				$database->setVillageField($data['from'], $exp, $value);
+
+				// Report: new village founded (issue #178)
+				$ncoor = $database->getCoor($data['to']);
+				$database->addNotice($to['owner'], $data['to'], 0, 24, 'New village founded', ($ncoor['x'] ?? 0) . ',' . ($ncoor['y'] ?? 0), time());
             }else{
                 // here must come movement from returning settlers
                 $types[] = 4;
@@ -2998,6 +3002,10 @@ class Automation {
                 $refs[] = $data['ref'];
                 $times[] = $time;
                 $endtimes[] = $time + ($time - $data['starttime']);
+
+                // Report: valley already occupied, settlers returning (issue #178)
+                $fcoor = $database->getCoor($data['to']);
+                $database->addNotice($to['owner'], $data['to'], 0, 25, 'Settlers returned - valley occupied', ($fcoor['x'] ?? 0) . ',' . ($fcoor['y'] ?? 0), time());
             }
         }
 

--- a/GameEngine/Lang/en.php
+++ b/GameEngine/Lang/en.php
@@ -2333,6 +2333,12 @@ tz_def('TZ_RT_REINF_IN', "Reinforcement in");
 tz_def('TZ_RT_ELDERS_REINF', "village of the elders reinforcement");
 tz_def('TZ_RT_UNOCC_OASIS', "Unoccupied Oasis");
 
+// ===== settler reports (issue #178) =====
+tz_def('TZ_RT_NEW_VILLAGE', "New village founded");
+tz_def('TZ_RT_VALLEY_OCCUPIED', "Settling failed (valley occupied)");
+tz_def('TZ_NEW_VILLAGE_MSG', "You have founded a new village:");
+tz_def('TZ_VALLEY_OCCUPIED_MSG', "Your settlers could not settle here - the valley is already occupied by another player. They are on their way back.");
+
 // ===== display-time localization of stored report topics =====
 // Reports are generated server-side at battle resolution and stored in the DB
 // (column `topic`) with English connectors. This rewrites them to the viewing
@@ -2350,6 +2356,8 @@ if (!function_exists('tz_loc_topic')) {
             ' attacks '                            => ' '.TZ_RT_ATTACKS.' ',
             ' reinforcement '                      => ' '.TZ_RT_REINFORCEMENT.' ',
             'Unoccupied Oasis'                     => TZ_RT_UNOCC_OASIS,
+            'New village founded'                  => TZ_RT_NEW_VILLAGE,
+            'Settlers returned - valley occupied'  => TZ_RT_VALLEY_OCCUPIED,
         );
         return strtr($s, $map);
     }

--- a/GameEngine/Lang/fr.php
+++ b/GameEngine/Lang/fr.php
@@ -2337,5 +2337,9 @@ define('TZ_RT_WAS_ATTACKED', "a été attaqué");
 define('TZ_RT_REINF_IN', "Renfort dans");
 define('TZ_RT_ELDERS_REINF', "renfort du village des anciens");
 define('TZ_RT_UNOCC_OASIS', "Oasis inoccupée");
+define('TZ_RT_NEW_VILLAGE', "Nouveau village fondé");
+define('TZ_RT_VALLEY_OCCUPIED', "Colonisation échouée (vallée occupée)");
+define('TZ_NEW_VILLAGE_MSG', "Vous avez fondé un nouveau village :");
+define('TZ_VALLEY_OCCUPIED_MSG', "Vos colons n'ont pas pu s'installer ici — la vallée est déjà occupée par un autre joueur. Ils sont sur le chemin du retour.");
 
 ?>

--- a/GameEngine/Lang/it.php
+++ b/GameEngine/Lang/it.php
@@ -2223,5 +2223,9 @@ define('TZ_RT_WAS_ATTACKED', "è stato attaccato");
 define('TZ_RT_REINF_IN', "Rinforzo in");
 define('TZ_RT_ELDERS_REINF', "rinforzo del villaggio degli anziani");
 define('TZ_RT_UNOCC_OASIS', "Oasi non occupata");
+define('TZ_RT_NEW_VILLAGE', "Nuovo villaggio fondato");
+define('TZ_RT_VALLEY_OCCUPIED', "Colonizzazione fallita (valle occupata)");
+define('TZ_NEW_VILLAGE_MSG', "Hai fondato un nuovo villaggio:");
+define('TZ_VALLEY_OCCUPIED_MSG', "I tuoi coloni non hanno potuto insediarsi qui — la valle è già occupata da un altro giocatore. Stanno tornando indietro.");
 
 ?>

--- a/GameEngine/Lang/ro.php
+++ b/GameEngine/Lang/ro.php
@@ -2326,3 +2326,7 @@ define('TZ_RT_WAS_ATTACKED', "a fost atacat");
 define('TZ_RT_REINF_IN', "Întărire în");
 define('TZ_RT_ELDERS_REINF', "întărire a satului bătrânilor");
 define('TZ_RT_UNOCC_OASIS', "Oază neocupată");
+define('TZ_RT_NEW_VILLAGE', "Sat nou întemeiat");
+define('TZ_RT_VALLEY_OCCUPIED', "Colonizare eșuată (vale ocupată)");
+define('TZ_NEW_VILLAGE_MSG', "Ai întemeiat un sat nou:");
+define('TZ_VALLEY_OCCUPIED_MSG', "Coloniștii tăi nu s-au putut stabili aici — valea este deja ocupată de alt jucător. Se întorc acasă.");

--- a/GameEngine/Lang/zh.php
+++ b/GameEngine/Lang/zh.php
@@ -2319,3 +2319,7 @@ define('TZ_RT_WAS_ATTACKED', "遭到攻击");
 define('TZ_RT_REINF_IN', "增援于");
 define('TZ_RT_ELDERS_REINF', "长老村增援");
 define('TZ_RT_UNOCC_OASIS', "无人占领的绿洲");
+define('TZ_RT_NEW_VILLAGE', "已建立新村庄");
+define('TZ_RT_VALLEY_OCCUPIED', "拓殖失败（山谷已被占领）");
+define('TZ_NEW_VILLAGE_MSG', "你已建立一个新村庄：");
+define('TZ_VALLEY_OCCUPIED_MSG', "你的拓荒者无法在此定居——该山谷已被其他玩家占领。他们正在返回途中。");

--- a/GameEngine/Message.php
+++ b/GameEngine/Message.php
@@ -130,7 +130,7 @@ class Message
                     $type = [1, 2, 3, 4, 5, 6, 7];
                     break;
                 case 4:
-                    $type = [0, 18, 19, 20, 21];
+                    $type = [0, 18, 19, 20, 21, 24, 25];
                     break;
                 case 5:
                     if (!$session->plus) {
@@ -442,6 +442,11 @@ class Message
             // Festive reports
             case 23:
                 return 22;
+
+            // Settler reports: new village founded / valley occupied (issue #178)
+            case 24:
+            case 25:
+                return 24;
         }
         return $type;
     }

--- a/Templates/Notice/24.tpl
+++ b/Templates/Notice/24.tpl
@@ -1,0 +1,51 @@
+<?php
+#################################################################################
+#  Settler reports (24.tpl) - issue #178
+#  Handles ntype 24 (new village founded) and ntype 25 (valley occupied).
+#  Title is stored in English and localized at display via tz_loc_topic().
+#  Body is built from localized constants + coordinates stored in `data`.
+#################################################################################
+
+$ntype  = (int)($message->readingNotice['ntype'] ?? 24);
+$coords = explode(',', (string)($message->readingNotice['data'] ?? ''));
+$x      = (int)($coords[0] ?? 0);
+$y      = (int)($coords[1] ?? 0);
+$wref   = (int)($message->readingNotice['toWref'] ?? 0);
+$mapCheck = $generator->getMapCheck($wref);
+$coordLink = '<a href="karte.php?d=' . $wref . '&c=' . $mapCheck . '">(' . $x . '|' . $y . ')</a>';
+?>
+
+<table cellpadding="1" cellspacing="1" id="report_surround">
+<thead>
+
+<tr>
+    <th><?php echo SUBJECT; ?>:</th>
+    <th><?php echo tz_loc_topic($message->readingNotice['topic']); ?></th>
+</tr>
+
+<tr>
+    <?php $date = $generator->procMtime($message->readingNotice['time']); ?>
+    <td class="sent"><?php echo TZ_SENT; ?></td>
+    <td><?php echo ON; ?> <span><?php echo $date[0] . " " . $date[1]; ?></span></td>
+</tr>
+
+</thead>
+
+<tbody>
+<tr><td colspan="2" class="empty"></td></tr>
+<tr><td colspan="2" class="report_content">
+
+<?php
+if ($ntype == 25) {
+    // Settlers could not settle - the valley is already occupied
+    echo TZ_VALLEY_OCCUPIED_MSG . ' ' . $coordLink;
+} else {
+    // New village founded
+    $vname = htmlspecialchars((string)$database->getVillageField($wref, 'name'), ENT_QUOTES, 'UTF-8');
+    echo TZ_NEW_VILLAGE_MSG . ' <b>' . $vname . '</b> ' . $coordLink;
+}
+?>
+
+</td></tr>
+</tbody>
+</table>

--- a/Templates/Notice/all.tpl
+++ b/Templates/Notice/all.tpl
@@ -35,6 +35,10 @@ $noticeClass = [
     TZ_RPT_SCOUT
 ];
 
+// Settler reports (issue #178) - sparse indices 24/25
+$noticeClass[24] = TZ_RT_NEW_VILLAGE;
+$noticeClass[25] = TZ_RT_VALLEY_OCCUPIED;
+
 // ======================== GOLD CHECK (cached query) ========================
 $uid = (int)$session->uid;
 
@@ -175,6 +179,14 @@ for ($i = (1 + $s); $i <= (10 + $s); $i++) {
         } elseif ($type >= 18 && $type <= 22) {
 
             echo "<img src=\"gpack/travian_default/img/scouts/".$type.".gif\"
+                   alt=\"".$noticeClass[$type]."\"
+                   title=\"".$noticeClass[$type]."\" />";
+
+        } elseif ($type == 24 || $type == 25) {
+
+            // Settler reports (issue #178): no dedicated gpack icon, reuse an existing one
+            $iconType = ($type == 24) ? 8 : 3;
+            echo "<img src=\"img/x.gif\" class=\"iReport iReport".$iconType."\"
                    alt=\"".$noticeClass[$type]."\"
                    title=\"".$noticeClass[$type]."\" />";
 


### PR DESCRIPTION
Closes #178.

Settlers produced no report on arrival. This adds the two missing reports.

## What it does
- **New village founded** (`ntype 24`): when settlers reach a free valley and the
  new village is created, the owner gets a report with the village name and coordinates.
- **Settling failed / valley occupied** (`ntype 25`): when the target valley has been
  taken by another player in the meantime, the settlers turn back and the owner gets a
  report explaining why.

Both are generated server-side in `Automation::sendSettlersComplete()`, on the existing
success/return branches.

## Plumbing
- `Message::getReportType()`: maps `24`/`25` to the new detail template.
- `Message::noticeType()`: lists `24`/`25` under the **Miscellaneous** tab.
- `Templates/Notice/24.tpl` (new): detail page; renders the localized body
  (founded vs occupied) from the coordinates stored in `data` and the village name
  resolved via `toWref`.
- `Templates/Notice/all.tpl`: subject tooltips for the new types + an icon (reuses an
  existing `iReport` class — the gpack has no dedicated settler icon).
- `Lang/{en,fr,ro,it,zh}.php`: new constants + `tz_loc_topic()` entries, so the stored
  English topic is localized at display time (same approach as #186 — works for old and
  new reports, per viewer language).

## Notes
- No schema changes; topics are stored in English and localized at render time.
- PHP 8.3, `php -l` clean on all touched files.
- Tested on my own server: the "new village founded" report shows the correct name and
  coordinates; the "valley occupied" case shows the failure report and the settlers return.
  Please also test on your side.

🇬🇧🇫🇷🇷🇴🇮🇹🇨🇳