### PR TITLE
fix: blank in-game help + untranslated profile after l10n (#189)

### DIFF
--- a/GameEngine/Lang/en.php
+++ b/GameEngine/Lang/en.php
@@ -2339,6 +2339,26 @@ tz_def('TZ_RT_VALLEY_OCCUPIED', "Settling failed (valley occupied)");
 tz_def('TZ_NEW_VILLAGE_MSG', "You have founded a new village:");
 tz_def('TZ_VALLEY_OCCUPIED_MSG', "Your settlers could not settle here - the valley is already occupied by another player. They are on their way back.");
 
+// ===== player profile page (#189) =====
+tz_def('AGE', 'Age');
+tz_def('CAPITAL_TAG', 'Capital');
+tz_def('WRITE_MESSAGE_UNAVAILABLE', 'Write message not available');
+tz_def('PROFILE_FLAG_ADMIN', 'This player is Admin.');
+tz_def('PROFILE_FLAG_MULTIHUNTER', 'This player is Multihunter.');
+tz_def('PROFILE_FLAG_BANNED', 'This player is BANNED.');
+tz_def('PROFILE_FLAG_VACATION', 'This player is on VACATION.');
+
+// ===== in-game manual overview page (#189) =====
+tz_def('BUILDINGS', 'Buildings');
+tz_def('INFRASTRUCTURE', 'Infrastructure');
+tz_def('FORWARD', 'forward');
+tz_def('NEW_FEATURES', 'New features');
+tz_def('NEW_WINDOW', 'new window');
+tz_def('MANUAL_INTRO', 'This ingame help offers you the chance to look up important information at any time.');
+tz_def('MANUAL_NEW_FEATURES_DESC', 'These are new features that you will not find in the real version of the game Travian T3.6. Here you can get acquainted with all new features in more detail.');
+tz_def('MANUAL_FAQ', 'Travian FAQ');
+tz_def('MANUAL_FAQ_DESC', 'This ingame help just gives you brief information. More information is available at the');
+
 // ===== display-time localization of stored report topics =====
 // Reports are generated server-side at battle resolution and stored in the DB
 // (column `topic`) with English connectors. This rewrites them to the viewing

--- a/GameEngine/Lang/fr.php
+++ b/GameEngine/Lang/fr.php
@@ -2342,4 +2342,24 @@ define('TZ_RT_VALLEY_OCCUPIED', "Colonisation échouée (vallée occupée)");
 define('TZ_NEW_VILLAGE_MSG', "Vous avez fondé un nouveau village :");
 define('TZ_VALLEY_OCCUPIED_MSG', "Vos colons n'ont pas pu s'installer ici — la vallée est déjà occupée par un autre joueur. Ils sont sur le chemin du retour.");
 
+// ===== profil du joueur (#189) =====
+define('AGE', 'Âge');
+define('CAPITAL_TAG', 'Capitale');
+define('WRITE_MESSAGE_UNAVAILABLE', 'Écrire un message non disponible');
+define('PROFILE_FLAG_ADMIN', 'Ce joueur est Administrateur.');
+define('PROFILE_FLAG_MULTIHUNTER', 'Ce joueur est Multihunter.');
+define('PROFILE_FLAG_BANNED', 'Ce joueur est BANNI.');
+define('PROFILE_FLAG_VACATION', 'Ce joueur est en VACANCES.');
+
+// ===== page d'accueil du manuel en jeu (#189) =====
+define('BUILDINGS', 'Bâtiments');
+define('INFRASTRUCTURE', 'Infrastructure');
+define('FORWARD', 'suivant');
+define('NEW_FEATURES', 'Nouveautés');
+define('NEW_WINDOW', 'nouvelle fenêtre');
+define('MANUAL_INTRO', 'Cette aide en jeu vous permet de consulter des informations importantes à tout moment.');
+define('MANUAL_NEW_FEATURES_DESC', "Ce sont des nouveautés que vous ne trouverez pas dans la version originale du jeu Travian T3.6. Vous pouvez ici découvrir toutes ces nouveautés en détail.");
+define('MANUAL_FAQ', 'FAQ Travian');
+define('MANUAL_FAQ_DESC', "Cette aide en jeu ne donne que de brèves informations. Plus d'informations sont disponibles sur le");
+
 ?>

--- a/GameEngine/Lang/it.php
+++ b/GameEngine/Lang/it.php
@@ -2228,4 +2228,24 @@ define('TZ_RT_VALLEY_OCCUPIED', "Colonizzazione fallita (valle occupata)");
 define('TZ_NEW_VILLAGE_MSG', "Hai fondato un nuovo villaggio:");
 define('TZ_VALLEY_OCCUPIED_MSG', "I tuoi coloni non hanno potuto insediarsi qui — la valle è già occupata da un altro giocatore. Stanno tornando indietro.");
 
+// ===== profilo del giocatore (#189) =====
+define('AGE', 'Età');
+define('CAPITAL_TAG', 'Capitale');
+define('WRITE_MESSAGE_UNAVAILABLE', 'Invio messaggio non disponibile');
+define('PROFILE_FLAG_ADMIN', 'Questo giocatore è Amministratore.');
+define('PROFILE_FLAG_MULTIHUNTER', 'Questo giocatore è Multihunter.');
+define('PROFILE_FLAG_BANNED', 'Questo giocatore è BANNATO.');
+define('PROFILE_FLAG_VACATION', 'Questo giocatore è in VACANZA.');
+
+// ===== pagina principale del manuale di gioco (#189) =====
+define('BUILDINGS', 'Edifici');
+define('INFRASTRUCTURE', 'Infrastruttura');
+define('FORWARD', 'avanti');
+define('NEW_FEATURES', 'Novità');
+define('NEW_WINDOW', 'nuova finestra');
+define('MANUAL_INTRO', "Questo aiuto di gioco ti permette di consultare informazioni importanti in qualsiasi momento.");
+define('MANUAL_NEW_FEATURES_DESC', "Queste sono novità che non troverai nella versione reale del gioco Travian T3.6. Qui puoi conoscere tutte le novità in dettaglio.");
+define('MANUAL_FAQ', 'FAQ Travian');
+define('MANUAL_FAQ_DESC', "Questo aiuto di gioco fornisce solo brevi informazioni. Maggiori informazioni sono disponibili sul");
+
 ?>

--- a/GameEngine/Lang/ro.php
+++ b/GameEngine/Lang/ro.php
@@ -2330,3 +2330,23 @@ define('TZ_RT_NEW_VILLAGE', "Sat nou întemeiat");
 define('TZ_RT_VALLEY_OCCUPIED', "Colonizare eșuată (vale ocupată)");
 define('TZ_NEW_VILLAGE_MSG', "Ai întemeiat un sat nou:");
 define('TZ_VALLEY_OCCUPIED_MSG', "Coloniștii tăi nu s-au putut stabili aici — valea este deja ocupată de alt jucător. Se întorc acasă.");
+
+// ===== profilul jucătorului (#189) =====
+define('AGE', 'Vârstă');
+define('CAPITAL_TAG', 'Capitală');
+define('WRITE_MESSAGE_UNAVAILABLE', 'Trimitere mesaj indisponibilă');
+define('PROFILE_FLAG_ADMIN', 'Acest jucător este Administrator.');
+define('PROFILE_FLAG_MULTIHUNTER', 'Acest jucător este Multihunter.');
+define('PROFILE_FLAG_BANNED', 'Acest jucător este BANAT.');
+define('PROFILE_FLAG_VACATION', 'Acest jucător este în VACANȚĂ.');
+
+// ===== pagina principală a manualului din joc (#189) =====
+define('BUILDINGS', 'Clădiri');
+define('INFRASTRUCTURE', 'Infrastructură');
+define('FORWARD', 'înainte');
+define('NEW_FEATURES', 'Funcții noi');
+define('NEW_WINDOW', 'fereastră nouă');
+define('MANUAL_INTRO', 'Acest ajutor din joc îți oferă posibilitatea de a consulta informații importante oricând.');
+define('MANUAL_NEW_FEATURES_DESC', "Acestea sunt funcții noi pe care nu le vei găsi în versiunea reală a jocului Travian T3.6. Aici te poți familiariza cu toate funcțiile noi în detaliu.");
+define('MANUAL_FAQ', 'Întrebări frecvente Travian');
+define('MANUAL_FAQ_DESC', "Acest ajutor din joc îți oferă doar informații scurte. Mai multe informații sunt disponibile pe");

--- a/GameEngine/Lang/zh.php
+++ b/GameEngine/Lang/zh.php
@@ -2323,3 +2323,23 @@ define('TZ_RT_NEW_VILLAGE', "已建立新村庄");
 define('TZ_RT_VALLEY_OCCUPIED', "拓殖失败（山谷已被占领）");
 define('TZ_NEW_VILLAGE_MSG', "你已建立一个新村庄：");
 define('TZ_VALLEY_OCCUPIED_MSG', "你的拓荒者无法在此定居——该山谷已被其他玩家占领。他们正在返回途中。");
+
+// ===== 玩家资料页 (#189) =====
+define('AGE', '年龄');
+define('CAPITAL_TAG', '首都');
+define('WRITE_MESSAGE_UNAVAILABLE', '无法发送消息');
+define('PROFILE_FLAG_ADMIN', '该玩家是管理员。');
+define('PROFILE_FLAG_MULTIHUNTER', '该玩家是多账号猎人。');
+define('PROFILE_FLAG_BANNED', '该玩家已被封禁。');
+define('PROFILE_FLAG_VACATION', '该玩家处于度假模式。');
+
+// ===== 游戏内手册首页 (#189) =====
+define('BUILDINGS', '建筑');
+define('INFRASTRUCTURE', '基础设施');
+define('FORWARD', '下一页');
+define('NEW_FEATURES', '新功能');
+define('NEW_WINDOW', '新窗口');
+define('MANUAL_INTRO', '此游戏内帮助让你随时查阅重要信息。');
+define('MANUAL_NEW_FEATURES_DESC', '这些是你在原版 Travian T3.6 游戏中找不到的新功能。你可以在此详细了解所有新功能。');
+define('MANUAL_FAQ', 'Travian 常见问题');
+define('MANUAL_FAQ_DESC', '此游戏内帮助仅提供简要信息。更多信息请访问');

--- a/GameEngine/Session.php
+++ b/GameEngine/Session.php
@@ -55,6 +55,11 @@ include_once("Generator.php");
 include_once("Multisort.php");
 include_once("Ranking.php");
 include_once("Lang/" . LANG . ".php");
+// en.php is an idempotent fallback (tz_def only defines missing keys); loading
+// it after the player language guarantees every interface constant is defined,
+// so a key missing from a translation degrades to English instead of a PHP 8.3
+// "undefined constant" fatal (blank page). See issue #189.
+include_once("Lang/en.php");
 include_once("Logging.php");
 include_once("Message.php");
 include_once("Alliance.php");

--- a/Templates/Manual/00.tpl
+++ b/Templates/Manual/00.tpl
@@ -1,9 +1,9 @@
 <h1><img class="point" src="img/x.gif" alt="" title="" /> <?php echo OVERVIEW; ?></h1>
-<p>This ingame help offers you the chance to look up important information at any time.</p>
+<p><?php echo MANUAL_INTRO; ?></p>
 <img class="troops" src="img/x.gif" alt="<?php echo TROOPS; ?>" title="<?php echo TROOPS; ?>" />
-<img class="buildings" src="img/x.gif" alt="Buildings" title="Buildings" />
+<img class="buildings" src="img/x.gif" alt="<?php echo BUILDINGS; ?>" title="<?php echo BUILDINGS; ?>" />
 <ul>
-<li><a href="manual.php?s=1&amp;typ=2">The troops</a></li>
+<li><a href="manual.php?s=1&amp;typ=2"><?php echo TROOPS; ?></a></li>
 
 <ul>
 	<li><a href="manual.php?typ=2&amp;s=1"><?php echo TRIBE1; ?></a></li>
@@ -17,24 +17,24 @@
 
 <br>
 
-<li><a href="manual.php?typ=3&amp;s=1">The buildings</a></li>
+<li><a href="manual.php?typ=3&amp;s=1"><?php echo BUILDINGS; ?></a></li>
 
 <ul>
     <li><a href="manual.php?typ=3&amp;s=1"><?php echo RESOURCES; ?></a></li>
     <li><a href="manual.php?typ=3&amp;s=2"><?php echo Q17_BUTN1; ?></a></li>
-    <li><a href="manual.php?typ=3&amp;s=3">Infrastructure</a></li>
+    <li><a href="manual.php?typ=3&amp;s=3"><?php echo INFRASTRUCTURE; ?></a></li>
 </ul>
 
 <br>
 <?php if(NEW_FUNCTIONS_OASIS || NEW_FUNCTIONS_ALLIANCE_INVITATION || NEW_FUNCTIONS_EMBASSY_MECHANICS || NEW_FUNCTIONS_FORUM_POST_MESSAGE || NEW_FUNCTIONS_TRIBE_IMAGES || NEW_FUNCTIONS_MHS_IMAGES || NEW_FUNCTIONS_DISPLAY_ARTIFACT || NEW_FUNCTIONS_DISPLAY_WONDER || NEW_FUNCTIONS_VACATION || NEW_FUNCTIONS_DISPLAY_CATAPULT_TARGET || NEW_FUNCTIONS_MANUAL_NATURENATARS || NEW_FUNCTIONS_DISPLAY_LINKS || NEW_FUNCTIONS_MEDAL_3YEAR || NEW_FUNCTIONS_MEDAL_5YEAR || NEW_FUNCTIONS_MEDAL_10YEAR) { ?>
-<li><a href="manual.php?typ=13&amp;s=31">New features</a><br>These are new features that you will not find in the real version of the game Travian T3.6. Here you can get acquainted with all new features in more detail.</li><br>
+<li><a href="manual.php?typ=13&amp;s=31"><?php echo NEW_FEATURES; ?></a><br><?php echo MANUAL_NEW_FEATURES_DESC; ?></li><br>
 <?php } ?>
 
-<li><a href="anleitung.php?s=3" target="_blank">Travian FAQ <img class="external" src="img/x.gif" alt="new window" title="new window" /></a><br>This ingame help just gives you brief information. More information is available at the <a href="http://travian.wikia.com/wiki/Travian_Wiki" target=blank>Fandom Travian Wiki</a>.</li>
+<li><a href="anleitung.php?s=3" target="_blank"><?php echo MANUAL_FAQ; ?> <img class="external" src="img/x.gif" alt="<?php echo NEW_WINDOW; ?>" title="<?php echo NEW_WINDOW; ?>" /></a><br><?php echo MANUAL_FAQ_DESC; ?> <a href="http://travian.wikia.com/wiki/Travian_Wiki" target=blank>Fandom Travian Wiki</a>.</li>
 </ul>
 <map id="nav" name="nav">
     <area href="manual.php?typ=3&amp;s=3" title="<?php echo BACK; ?>" coords="0,0,45,18" shape="rect" alt="" />
     <area href="manual.php?s=1" title="<?php echo OVERVIEW; ?>" coords="46,0,70,18" shape="rect" alt="" />
-    <area href="manual.php?typ=2&amp;s=1" title="forward" coords="71,0,116,18" shape="rect" alt="" />
+    <area href="manual.php?typ=2&amp;s=1" title="<?php echo FORWARD; ?>" coords="71,0,116,18" shape="rect" alt="" />
 </map>
 <img usemap="#nav" src="img/x.gif" class="navi" alt="" />

--- a/Templates/Profile/menu.tpl
+++ b/Templates/Profile/menu.tpl
@@ -27,7 +27,7 @@ $sParam = isset($_GET['s']) ? (int)$_GET['s'] : null;
     <!-- ================= OVERVIEW ================= -->
     <a href="spieler.php?uid=<?php echo $menuUid; ?>"
        <?php echo $selectedUid ? 'class="selected"' : ''; ?>>
-        Overview
+        <?php echo OVERVIEW; ?>
     </a>
 
     |
@@ -35,7 +35,7 @@ $sParam = isset($_GET['s']) ? (int)$_GET['s'] : null;
     <!-- ================= PROFILE ================= -->
     <a href="spieler.php?s=1"
        <?php echo ($sParam === 1) ? 'class="selected"' : ''; ?>>
-        Profile
+        <?php echo PROFILE; ?>
     </a>
 
     |
@@ -43,7 +43,7 @@ $sParam = isset($_GET['s']) ? (int)$_GET['s'] : null;
     <!-- ================= PREFERENCES ================= -->
     <a href="spieler.php?s=2"
        <?php echo ($sParam === 2) ? 'class="selected"' : ''; ?>>
-        Preferences
+        <?php echo PREFERENCES; ?>
     </a>
 
     |
@@ -51,7 +51,7 @@ $sParam = isset($_GET['s']) ? (int)$_GET['s'] : null;
     <!-- ================= ACCOUNT ================= -->
     <a href="spieler.php?s=3"
        <?php echo ($sParam === 3) ? 'class="selected"' : ''; ?>>
-        Account
+        <?php echo ACCOUNT; ?>
     </a>
 
     <?php
@@ -61,7 +61,7 @@ $sParam = isset($_GET['s']) ? (int)$_GET['s'] : null;
         |
         <a href="spieler.php?s=5"
            <?php echo ($sParam === 5) ? 'class="selected"' : ''; ?>>
-            Vacation
+            <?php echo VACATION; ?>
         </a>
     <?php
     }
@@ -72,7 +72,7 @@ $sParam = isset($_GET['s']) ? (int)$_GET['s'] : null;
         |
         <a href="spieler.php?s=4"
            <?php echo ($sParam === 4) ? 'class="selected"' : ''; ?>>
-            Graphic pack
+            <?php echo GRAPH_PACK; ?>
         </a>
     <?php
     }

--- a/Templates/Profile/menu2.tpl
+++ b/Templates/Profile/menu2.tpl
@@ -24,7 +24,7 @@ $hasUid  = isset($_GET['uid']);
     <!-- ================= OVERVIEW (ACTIVE) ================= -->
     <a href="spieler.php?uid=<?php echo $menuUid; ?>"
        <?php echo $hasUid ? 'class="selected"' : ''; ?>>
-        Overview
+        <?php echo OVERVIEW; ?>
     </a>
 
     |

--- a/Templates/Profile/overview.tpl
+++ b/Templates/Profile/overview.tpl
@@ -85,7 +85,7 @@ if ($uid == $session->uid) {
 
 <tr>
     <th colspan="2">
-        Player <?php echo htmlspecialchars($displayarray['username'], ENT_QUOTES, 'UTF-8'); ?>
+        <?php echo PLAYER; ?> <?php echo htmlspecialchars($displayarray['username'], ENT_QUOTES, 'UTF-8'); ?>
     </th>
 </tr>
 
@@ -94,16 +94,16 @@ if ($uid == $session->uid) {
 // STATUS FLAGS
 // =========================
 if ($displayarray['access'] == ADMIN)
-    echo "<tr><th colspan='2'><font color='Red'><center><b>This player is Admin.</b></center></font></th></tr>";
+    echo "<tr><th colspan='2'><font color='Red'><center><b>".PROFILE_FLAG_ADMIN."</b></center></font></th></tr>";
 
 if ($displayarray['access'] == MULTIHUNTER)
-    echo "<tr><th colspan='2'><font color='Blue'><center><b>This player is Multihunter.</b></center></font></th></tr>";
+    echo "<tr><th colspan='2'><font color='Blue'><center><b>".PROFILE_FLAG_MULTIHUNTER."</b></center></font></th></tr>";
 
 if ($displayarray['access'] == BANNED)
-    echo "<tr><th colspan='2'><font color='Green'><center><b>This player is BANNED.</b></center></font></th></tr>";
+    echo "<tr><th colspan='2'><font color='Green'><center><b>".PROFILE_FLAG_BANNED."</b></center></font></th></tr>";
 
 if ($displayarray['vac_mode'] == 1)
-    echo "<tr><th colspan='2'><font color='Maroon'><center><b>This player is on VACATION.</b></center></font></th></tr>";
+    echo "<tr><th colspan='2'><font color='Maroon'><center><b>".PROFILE_FLAG_VACATION."</b></center></font></th></tr>";
 ?>
 
 <tr>
@@ -185,14 +185,14 @@ if (!empty($displayarray['birthday'])) {
         if (date('d') < substr($displayarray['birthday'], 8, 2)) $age--;
     }
 
-    echo "<tr><th>Age</th><td>$age</td></tr>";
+    echo "<tr><th>".AGE."</th><td>$age</td></tr>";
 }
 
 // =========================
 // GENDER
 // =========================
 if (!empty($displayarray['gender'])) {
-    $gender = ($displayarray['gender'] == 1) ? "Male" : "Female";
+    $gender = ($displayarray['gender'] == 1) ? MALE : FEMALE;
     echo "<tr><th>".GENDER."</th><td>$gender</td></tr>";
 }
 
@@ -228,9 +228,9 @@ if ($uid == $session->uid) {
     // OWN PROFILE ACTION
     // =========================
     if ($session->sit == 0) {
-        echo '<td colspan="2"><a href="spieler.php?s=1">&raquo; Change profile</a></td>';
+        echo '<td colspan="2"><a href="spieler.php?s=1">&raquo; '.CHANGE_PROFILE.'</a></td>';
     } else {
-        echo '<td colspan="2"><span class="none"><b>&raquo; Change profile</b></span></td>';
+        echo '<td colspan="2"><span class="none"><b>&raquo; '.CHANGE_PROFILE.'</b></span></td>';
     }
 
 } else {
@@ -240,11 +240,11 @@ if ($uid == $session->uid) {
     // =========================
     if ($isNatar || $isNature) {
 
-        echo '<td colspan="2"><span class="none"><b>&raquo; Write message not available</b></span></td>';
+        echo '<td colspan="2"><span class="none"><b>&raquo; '.WRITE_MESSAGE_UNAVAILABLE.'</b></span></td>';
 
     } else {
 
-        echo '<td colspan="2"><a href="nachrichten.php?t=1&amp;id=' . (int)$uid . '">&raquo; Write message</a></td>';
+        echo '<td colspan="2"><a href="nachrichten.php?t=1&amp;id=' . (int)$uid . '">&raquo; '.WRITE_MESSAGE.'</a></td>';
     }
 }
 ?>
@@ -282,7 +282,7 @@ if ($uid == $session->uid) {
 
 <tr>
     <th colspan="<?php echo (defined('NEW_FUNCTIONS_OASIS') && NEW_FUNCTIONS_OASIS) ? 4 : 3; ?>">
-        Villages
+        <?php echo VILLAGES; ?>
     </th>
 </tr>
 
@@ -312,7 +312,7 @@ foreach ($varray as $vil) {
           . htmlspecialchars($vil['name'], ENT_QUOTES, 'UTF-8') .
           "</a>";
 
-    if ($vil['capital'] == 1) echo "<span class=\"none3\"> (Capital)</span>";
+    if ($vil['capital'] == 1) echo "<span class=\"none3\"> (".CAPITAL_TAG.")</span>";
 
     if (defined('NEW_FUNCTIONS_DISPLAY_ARTIFACT') && NEW_FUNCTIONS_DISPLAY_ARTIFACT) {
         if ($hasArtifact) echo "<span class=\"none3\"> (Artifact)</span>";

--- a/manual.php
+++ b/manual.php
@@ -15,6 +15,14 @@
 #################################################################################
 
 include_once("GameEngine/config.php");
+// Load the interface language for the manual templates. Since #186 these
+// templates use translation constants (OVERVIEW, TRIBE1, ...) instead of
+// hardcoded English; without a language file every constant would be
+// undefined and PHP 8.3 would fatal, leaving the in-game help iframe blank.
+// en.php is loaded last as an idempotent fallback (tz_def) to fill any key
+// missing from the active language.
+include_once("GameEngine/Lang/" . LANG . ".php");
+include_once("GameEngine/Lang/en.php");
 ?>
 
 <html>


### PR DESCRIPTION
Closes #189.

Two regressions introduced by the interface translation in #186.

## 1. Blank in-game help
`manual.php` (loaded in the `dorf1.php` help iframe) renders the `Templates/Manual/*`
templates, which #186 converted to translation constants (`OVERVIEW`, `TRIBE1`, …).
But `manual.php` only includes `config.php` and never loads a language file, so every
constant was undefined — and under PHP 8.3 an undefined constant is a **fatal Error**,
not a warning, so the iframe came back empty.

Fixed by loading the active language + `en.php` (idempotent `tz_def` fallback) in
`manual.php`, and fully localizing the manual overview page (`Templates/Manual/00.tpl`).

## 2. Player profile still in English
Both profile menus had their tab labels hardcoded in English — `menu.tpl` (your own
profile) and `menu2.tpl` (sitter view) — and `Templates/Profile/overview.tpl` still
had several hardcoded strings (Player, the Admin/Multihunter/Banned/Vacation status
flags, Age, Male/Female, Change profile, Write message, Villages, Capital). All now
use translation constants.

## Hardening (prevents this class of bug)
`en.php` is now also loaded as a fallback **after** the player language in `Session.php`.
Since `en.php` uses `tz_def()` (defines only missing keys), any key absent from a
translation degrades to English instead of fataling into a blank page — the player
language still wins for every key it defines.

## Added constants (en + fr/ro/it/zh)
`AGE`, `CAPITAL_TAG`, `WRITE_MESSAGE_UNAVAILABLE`, `PROFILE_FLAG_ADMIN`,
`PROFILE_FLAG_MULTIHUNTER`, `PROFILE_FLAG_BANNED`, `PROFILE_FLAG_VACATION`,
`BUILDINGS`, `INFRASTRUCTURE`, `FORWARD`, `NEW_FEATURES`, `NEW_WINDOW`,
`MANUAL_INTRO`, `MANUAL_NEW_FEATURES_DESC`, `MANUAL_FAQ`, `MANUAL_FAQ_DESC`.

## Out of scope (follow-up)
This PR fixes the two **regressions** and localizes the manual's overview/landing page.
The manual's **detailed pages** (each tribe, building and unit — ~150 `Templates/Manual/*.tpl`
files, hundreds of strings) are still in English. That is a **pre-existing gap** — the
whole manual was hardcoded English before #186, not something this change broke. Fully
translating it is a sizeable task that I'll submit as a separate dedicated PR.

No schema changes. PHP 8.3. Tested on my own server: the in-game help opens with
localized content again, and the player profile is fully localized. Please also test
on your side.