### PR TITLE
Refactor(sendunitsComplete): extract applyCatapults() [#155]

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -876,6 +876,158 @@ class Automation {
         }
     }
 
+    private function applyCatapults($data, $battlepart, $catp_pic, $can_destroy, $isoasis, $targettribe, $info_cat)
+    {
+        global $database;
+
+        // village_destroyed stays unset in the pop<=0 path of the original;
+        // downstream treats unset as 0, so initialising to 0 here is equivalent.
+        $village_destroyed = 0;
+
+                    			$pop = $this->recountPop($data['to']);
+                    			
+                    			// village has been destroyed
+                    			if ($pop <= 0) {
+                    				if ($can_destroy == 1) $info_cat = "".$catp_pic.", Village already destroyed.";
+                    				else $info_cat = "".$catp_pic.", Village can\'t be destroyed.";
+                    			}
+                    			else
+                    			{
+                    				// village stands, let's do the damage
+                    				/**
+                    				 * FIRST CATAPULTS ROW
+                    				 */
+                    				
+                    				$basearray = $data['to'];
+                    				$bdo = $database->getResourceLevel($basearray, false);
+                    				$catapultTarget = $data['ctar1'];
+                    				$catapultTarget2 = (isset($data['ctar2']) ? $data['ctar2'] : 0);
+                    				
+                    				$catapults1TargetRandom = ($catapultTarget == 0);
+                    				$catapults2WillNotShoot = ($catapultTarget2 == 0);
+                    				$catapults2TargetRandom = ($catapults2WillNotShoot || $catapultTarget2 == 99);
+                    				
+                    				// we're manually targetting 1st and/or 2nd row of catapults
+                    				if (!$catapults1TargetRandom)
+                    				{
+                    					$_catapultsTarget1Levels = [];
+                    					$__catapultsTarget1AltTargets = [];
+                    					
+                    					// calculate targets for 1st rows of catapults
+                    					$j = 0;
+                    					for ($i = 1; $i <= 41; $i++)
+                    					{
+                    						if ($i == 41) $i = 99;
+                    						
+                    						// 1st row of catapults pre-selected target calculations, if needed
+                    						if (!$catapults1TargetRandom && $bdo['f'.$i.'t'] == $catapultTarget && $bdo['f'.$i] > 0 && $i != 40)
+                    						{
+                    							$j++;
+                    							$_catapultsTarget1Levels[$j]=$bdo['f'.$i];
+                    							$__catapultsTarget1AltTargets[$j]=$i;
+                    						}
+                    					}
+                    					
+                    					// if we couldn't find a suitable target for 1st row of catapults,
+                    					// select a random target instead
+                    					if (!$catapults1TargetRandom) {
+                    						if ( count( $_catapultsTarget1Levels ) > 0 ) {
+                    							if ( max( $_catapultsTarget1Levels ) <= 0 ) {
+                    								$catapultTarget = 0;
+                    							} else {
+                    								$catapultTarget = $__catapultsTarget1AltTargets[rand( 1, $j )];
+                    							}
+                    						} else {
+                    							$catapultTarget = 0;
+                    							$catapults1TargetRandom = true;
+                    						}
+                    					}
+                    				}
+                    				
+                    				// 1st row of catapults set to target randomly
+                    				if ($catapults1TargetRandom)
+                    				{
+                    					$list = [];
+                    					for ($i = 1; $i <= 41; $i++)
+                    					{
+                    						if ($i == 41) $i = 99;
+                    						if ($bdo['f'.$i] > 0 && $i != 40) $list[] = $i;
+                    					}
+                    					$catapultTarget = $list[rand(0, count($list) - 1)];
+                    				}
+                    				
+                    				/**
+                    				 * resolve 1st row of catapults
+                    				 */
+                    				$village_destroyed = 0;
+                    				$this->resolveCatapultsDestruction($bdo, $battlepart, $info_cat, $data, $catapultTarget, !$catapults2WillNotShoot, false, $catp_pic, $can_destroy, $isoasis, $village_destroyed, $targettribe);
+                    				
+                    				/**
+                    				 * SECOND CATAPULTS ROW
+                    				 */
+                    				
+                    				// we're manually targetting 2nd row of catapults
+                    				if (!$catapults2TargetRandom)
+                    				{
+                    					$_catapultsTarget2Levels = [];
+                    					$__catapultsTarget2AltTargets = [];
+                    					
+                    					// calculate targets for 2nd rows of catapults
+                    					$j = 0;
+                    					for ($i = 1; $i <= 41; $i++)
+                    					{
+                    						if ($i == 41) $i = 99;
+                    						
+                    						// 2nd row of catapults pre-selected target calculations, if needed
+                    						if (!$catapults2TargetRandom && !$catapults2WillNotShoot && $bdo['f'.$i.'t'] == $catapultTarget2 && $bdo['f'.$i] > 0 && $i != 40)
+                    						{
+                    							$j++;
+                    							$_catapultsTarget2Levels[$j] = $bdo['f'.$i];
+                    							$__catapultsTarget2AltTargets[$j] = $i;
+                    						}
+                    					}
+                    					
+                    					// if we couldn't find a suitable target for 2nd row of catapults,
+                    					// select a random target instead
+                    					if (!$catapults2TargetRandom) {
+                    						if (count($_catapultsTarget2Levels) > 0 ) {
+                    							if (max($_catapultsTarget2Levels) <= 0 ) {
+                    								$catapultTarget2 = 99;
+                    							}
+                    							else $catapultTarget2 = $__catapultsTarget2AltTargets[rand( 1, $j )];
+                    						} else {
+                    							$catapultTarget2 = 99;
+                    							$catapults2TargetRandom = true;
+                    						}
+                    					}
+                    				}
+                    				
+                    				// 2nd row of catapults set to target randomly
+                    				if ($catapults2TargetRandom && !$catapults2WillNotShoot)
+                    				{
+                    					$list = [];
+                    					for ($i = 1; $i <= 41; $i++)
+                    					{
+                    						if ($i == 41) $i = 99;
+                    						if ($bdo['f'.$i] > 0 && $i != 40) $list[] = $i;
+                    					}
+                    					$catapultTarget2 = $list[ rand(0, count($list) - 1) ];
+                    				}
+                    				
+                    				/**
+                    				 * resolve 2nd row of catapults
+                    				 */
+                    				if (!$catapults2WillNotShoot) {
+                    					$this->resolveCatapultsDestruction($bdo, $battlepart, $info_cat, $data, $catapultTarget2, true, true, $catp_pic, $can_destroy, $isoasis, $village_destroyed, $targettribe);
+                    				}
+                    				
+                    				// clear resource levels cache, since we might have destroyed buildings/fields by now
+                    				call_user_func(get_class($database).'::clearResourseLevelsCache');
+                    			}
+
+        return ['battlepart' => $battlepart, 'info_cat' => $info_cat, 'village_destroyed' => $village_destroyed];
+    }
+
     private function claimMovementRecord($moveid) {
         global $database;
 
@@ -1729,146 +1881,10 @@ class Automation {
                     		
                     		if (($data['t8'] - $traped8) > 0)
                     		{
-                    			$pop = $this->recountPop($data['to']);
-                    			
-                    			// village has been destroyed
-                    			if ($pop <= 0) {
-                    				if ($can_destroy == 1) $info_cat = "".$catp_pic.", Village already destroyed.";
-                    				else $info_cat = "".$catp_pic.", Village can\'t be destroyed.";
-                    			}
-                    			else
-                    			{
-                    				// village stands, let's do the damage
-                    				/**
-                    				 * FIRST CATAPULTS ROW
-                    				 */
-                    				
-                    				$basearray = $data['to'];
-                    				$bdo = $database->getResourceLevel($basearray, false);
-                    				$catapultTarget = $data['ctar1'];
-                    				$catapultTarget2 = (isset($data['ctar2']) ? $data['ctar2'] : 0);
-                    				
-                    				$catapults1TargetRandom = ($catapultTarget == 0);
-                    				$catapults2WillNotShoot = ($catapultTarget2 == 0);
-                    				$catapults2TargetRandom = ($catapults2WillNotShoot || $catapultTarget2 == 99);
-                    				
-                    				// we're manually targetting 1st and/or 2nd row of catapults
-                    				if (!$catapults1TargetRandom)
-                    				{
-                    					$_catapultsTarget1Levels = [];
-                    					$__catapultsTarget1AltTargets = [];
-                    					
-                    					// calculate targets for 1st rows of catapults
-                    					$j = 0;
-                    					for ($i = 1; $i <= 41; $i++)
-                    					{
-                    						if ($i == 41) $i = 99;
-                    						
-                    						// 1st row of catapults pre-selected target calculations, if needed
-                    						if (!$catapults1TargetRandom && $bdo['f'.$i.'t'] == $catapultTarget && $bdo['f'.$i] > 0 && $i != 40)
-                    						{
-                    							$j++;
-                    							$_catapultsTarget1Levels[$j]=$bdo['f'.$i];
-                    							$__catapultsTarget1AltTargets[$j]=$i;
-                    						}
-                    					}
-                    					
-                    					// if we couldn't find a suitable target for 1st row of catapults,
-                    					// select a random target instead
-                    					if (!$catapults1TargetRandom) {
-                    						if ( count( $_catapultsTarget1Levels ) > 0 ) {
-                    							if ( max( $_catapultsTarget1Levels ) <= 0 ) {
-                    								$catapultTarget = 0;
-                    							} else {
-                    								$catapultTarget = $__catapultsTarget1AltTargets[rand( 1, $j )];
-                    							}
-                    						} else {
-                    							$catapultTarget = 0;
-                    							$catapults1TargetRandom = true;
-                    						}
-                    					}
-                    				}
-                    				
-                    				// 1st row of catapults set to target randomly
-                    				if ($catapults1TargetRandom)
-                    				{
-                    					$list = [];
-                    					for ($i = 1; $i <= 41; $i++)
-                    					{
-                    						if ($i == 41) $i = 99;
-                    						if ($bdo['f'.$i] > 0 && $i != 40) $list[] = $i;
-                    					}
-                    					$catapultTarget = $list[rand(0, count($list) - 1)];
-                    				}
-                    				
-                    				/**
-                    				 * resolve 1st row of catapults
-                    				 */
-                    				$village_destroyed = 0;
-                    				$this->resolveCatapultsDestruction($bdo, $battlepart, $info_cat, $data, $catapultTarget, !$catapults2WillNotShoot, false, $catp_pic, $can_destroy, $isoasis, $village_destroyed, $targettribe);
-                    				
-                    				/**
-                    				 * SECOND CATAPULTS ROW
-                    				 */
-                    				
-                    				// we're manually targetting 2nd row of catapults
-                    				if (!$catapults2TargetRandom)
-                    				{
-                    					$_catapultsTarget2Levels = [];
-                    					$__catapultsTarget2AltTargets = [];
-                    					
-                    					// calculate targets for 2nd rows of catapults
-                    					$j = 0;
-                    					for ($i = 1; $i <= 41; $i++)
-                    					{
-                    						if ($i == 41) $i = 99;
-                    						
-                    						// 2nd row of catapults pre-selected target calculations, if needed
-                    						if (!$catapults2TargetRandom && !$catapults2WillNotShoot && $bdo['f'.$i.'t'] == $catapultTarget2 && $bdo['f'.$i] > 0 && $i != 40)
-                    						{
-                    							$j++;
-                    							$_catapultsTarget2Levels[$j] = $bdo['f'.$i];
-                    							$__catapultsTarget2AltTargets[$j] = $i;
-                    						}
-                    					}
-                    					
-                    					// if we couldn't find a suitable target for 2nd row of catapults,
-                    					// select a random target instead
-                    					if (!$catapults2TargetRandom) {
-                    						if (count($_catapultsTarget2Levels) > 0 ) {
-                    							if (max($_catapultsTarget2Levels) <= 0 ) {
-                    								$catapultTarget2 = 99;
-                    							}
-                    							else $catapultTarget2 = $__catapultsTarget2AltTargets[rand( 1, $j )];
-                    						} else {
-                    							$catapultTarget2 = 99;
-                    							$catapults2TargetRandom = true;
-                    						}
-                    					}
-                    				}
-                    				
-                    				// 2nd row of catapults set to target randomly
-                    				if ($catapults2TargetRandom && !$catapults2WillNotShoot)
-                    				{
-                    					$list = [];
-                    					for ($i = 1; $i <= 41; $i++)
-                    					{
-                    						if ($i == 41) $i = 99;
-                    						if ($bdo['f'.$i] > 0 && $i != 40) $list[] = $i;
-                    					}
-                    					$catapultTarget2 = $list[ rand(0, count($list) - 1) ];
-                    				}
-                    				
-                    				/**
-                    				 * resolve 2nd row of catapults
-                    				 */
-                    				if (!$catapults2WillNotShoot) {
-                    					$this->resolveCatapultsDestruction($bdo, $battlepart, $info_cat, $data, $catapultTarget2, true, true, $catp_pic, $can_destroy, $isoasis, $village_destroyed, $targettribe);
-                    				}
-                    				
-                    				// clear resource levels cache, since we might have destroyed buildings/fields by now
-                    				call_user_func(get_class($database).'::clearResourseLevelsCache');
-                    			}
+                    			$catResult = $this->applyCatapults($data, $battlepart, $catp_pic, $can_destroy, $isoasis, $targettribe, $info_cat);
+                    			$battlepart        = $catResult['battlepart'];
+                    			$info_cat          = $catResult['info_cat'];
+                    			$village_destroyed = $catResult['village_destroyed'];
                     		}
                     	} elseif (($data['t7'] - $traped7) > 0) {
                     		$info_ram = "".$ram_pic.",Hint: The ram does not work during a raid.";


### PR DESCRIPTION
Phase B extraction (behaviour-preserving) of the catapults (t8) block from the
~1700-line `sendunitsComplete()` combat resolver into a private helper
`applyCatapults()`, placed next to the existing `resolveCatapultsDestruction()`.

**Scope is deliberately the t8 catapults block only** (the two targeting rows +
the calls to `resolveCatapultsDestruction()`). The rams block (t7) just above is
left untouched because it contains the `calculateBattle()` re-run when the wall
is damaged (~25 args), which needs a `$battleContext` array — that will be a
separate `applyRams()` step. Keeps this PR small and reviewable.

The block body is moved **verbatim** (no logic change). The caller keeps the
`if (($data['t8'] - $traped8) > 0)` guard and resyncs the three outputs the block
produces: `$battlepart` (the WW target-40 case can change it), `$info_cat`, and
`$village_destroyed`. `$village_destroyed` is initialised to 0 at the top of the
method, which is equivalent to the original (the pop<=0 path left it unset and
downstream treats unset as 0). `$data` is read-only inside
`resolveCatapultsDestruction()`, so passing it by value is safe; `$pop`/`$bdo`
and the targeting locals are not read after the block.

**Validation** — deterministic A/B combat harness, new `--catapult` scenario
(t1 infantry wins + t8 catapults at the unique Main Building → `rand(1,1)`):
- `--catapult --selfcheck`: IDENTICAL (deterministic)
- `--catapult`: catapults hit (Main Building 20→12), master vs refactor **IDENTICAL**
- Regression (common / evasion / scout): IDENTICAL

Brace balance even (635/635).