### PR TITLE
fix(quest): grant no-tasks shipment reward atomically [#129]

### DIFF
--- a/Templates/Ajax/quest_core.tpl
+++ b/Templates/Ajax/quest_core.tpl
@@ -344,21 +344,18 @@ if (isset($qact)){
 			break;
 
 		case '91':
-			$database->updateUserField($_SESSION['username'],'quest','91',0);
-			$database->updateUserField($_SESSION['username'],'quest_time',''.(time()+$skipp_time).'',0);
+			// Atomic, idempotent claim (issue #129): grant the reward only when the quest
+			// pointer actually advances 90 -> 91, so a concurrent or duplicated request
+			// cannot wipe the gold/Plus reward through a stale read-modify-write.
+			$now = time();
+			$claimed = mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users SET quest = 91 WHERE `username` = '".$user_sanitized."' AND quest = 90") && mysqli_affected_rows($database->dblink) === 1;
+			if ($claimed) {
+				$database->updateUserField($_SESSION['username'],'quest_time',''.($now+$skipp_time).'',0);
+				//Give Reward: 1 day of Plus + 15 gold (atomic increments)
+				mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users SET gold = gold + 15, plus = IF(plus > $now, plus + 86400, $now + 86400) WHERE `username` = '".$user_sanitized."'");
+			}
 			$_SESSION['qst']= 91;
 			$_SESSION['qst_time'] = time()+$skipp_time;
-			//Give Reward
-			if(!$session->plus){
-				mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users set plus = ('".mktime(date("H"),date("i"), date("s"),date("m") , date("d"), date("Y"))."')+86400 where `username`='".$user_sanitized."'") or die(mysqli_error());
-			} else {
-				$plus=$database->getUserField($_SESSION['username'],'plus','username');
-				$plus+=86400;
-				$database->updateUserField($_SESSION['username'],'plus',$plus,0);
-			}
-			$gold=$database->getUserField($_SESSION['username'],'gold','username');
-			$gold+=15;
-			$database->updateUserField($_SESSION['username'],'gold',$gold,0);
 			break;
 
 		case '92':
@@ -407,21 +404,16 @@ if (isset($qact)){
 			break;
 
 		case '97':
-			$database->updateUserField($_SESSION['username'],'quest','97',0);
-			$database->updateUserField($_SESSION['username'],'quest_time',''.(time()).'',0);
+			// Atomic, idempotent claim (issue #129): advance 96 -> 97 exactly once.
+			$now = time();
+			$claimed = mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users SET quest = 97 WHERE `username` = '".$user_sanitized."' AND quest = 96") && mysqli_affected_rows($database->dblink) === 1;
+			if ($claimed) {
+				$database->updateUserField($_SESSION['username'],'quest_time',''.$now.'',0);
+				//Give Reward: 2 days of Plus + 20 gold (atomic increments)
+				mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users SET gold = gold + 20, plus = IF(plus > $now, plus + 172800, $now + 172800) WHERE `username` = '".$user_sanitized."'");
+			}
 			$_SESSION['qst_time'] = time();
 			$_SESSION['qst']= 97;
-			//Give Reward 20 gold + 2 days plus
-			if(!$session->plus){
-				mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users set plus = ('".mktime(date("H"),date("i"), date("s"),date("m") , date("d"), date("Y"))."')+172800 where `username`='".$user_sanitized."'") or die(mysqli_error());
-			} else {
-				$plus=$database->getUserField($_SESSION['username'],'plus','username');
-				$plus+=172800;
-				$database->updateUserField($_SESSION['username'],'plus',$plus,0);
-			}
-			$gold=$database->getUserField($_SESSION['username'],'gold','username');
-			$gold+=20;
-			$database->updateUserField($_SESSION['username'],'gold',$gold,0);
 			break;
 		}
 	}

--- a/Templates/Ajax/quest_core25.tpl
+++ b/Templates/Ajax/quest_core25.tpl
@@ -324,21 +324,18 @@ if (isset($qact)){
 			break;
 
 		case '91':
-			$database->updateUserField($_SESSION['username'],'quest','91',0);
-			$database->updateUserField($_SESSION['username'],'quest_time',''.(time()+$skipp_time).'',0);
+			// Atomic, idempotent claim (issue #129): grant the reward only when the quest
+			// pointer actually advances 90 -> 91, so a concurrent or duplicated request
+			// cannot wipe the gold/Plus reward through a stale read-modify-write.
+			$now = time();
+			$claimed = mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users SET quest = 91 WHERE `username` = '".$user_sanitized."' AND quest = 90") && mysqli_affected_rows($database->dblink) === 1;
+			if ($claimed) {
+				$database->updateUserField($_SESSION['username'],'quest_time',''.($now+$skipp_time).'',0);
+				//Give Reward: 1 day of Plus + 15 gold (atomic increments)
+				mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users SET gold = gold + 15, plus = IF(plus > $now, plus + 86400, $now + 86400) WHERE `username` = '".$user_sanitized."'");
+			}
 			$_SESSION['qst']= 91;
 			$_SESSION['qst_time'] = time()+$skipp_time;
-			//Give Reward
-			if(!$session->plus){
-				mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users set plus = ('".mktime(date("H"),date("i"), date("s"),date("m") , date("d"), date("Y"))."')+86400 where `username`='".$user_sanitized."'") or die(mysqli_error($database->dblink));
-			} else {
-				$plus=$database->getUserField($_SESSION['username'],'plus',1);
-				$plus+=86400;
-				$database->updateUserField($_SESSION['username'],'plus',$plus,0);
-			}
-			$gold=$database->getUserField($_SESSION['username'],'gold',1);
-			$gold+=15;
-			$database->updateUserField($_SESSION['username'],'gold',$gold,0);
 			break;
 
 		case '92':
@@ -387,21 +384,16 @@ if (isset($qact)){
 			break;
 
 		case '97':
-			$database->updateUserField($_SESSION['username'],'quest','97',0);
-			$database->updateUserField($_SESSION['username'],'quest_time',''.(time()).'',0);
+			// Atomic, idempotent claim (issue #129): advance 96 -> 97 exactly once.
+			$now = time();
+			$claimed = mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users SET quest = 97 WHERE `username` = '".$user_sanitized."' AND quest = 96") && mysqli_affected_rows($database->dblink) === 1;
+			if ($claimed) {
+				$database->updateUserField($_SESSION['username'],'quest_time',''.$now.'',0);
+				//Give Reward: 2 days of Plus + 20 gold (atomic increments)
+				mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users SET gold = gold + 20, plus = IF(plus > $now, plus + 172800, $now + 172800) WHERE `username` = '".$user_sanitized."'");
+			}
 			$_SESSION['qst_time'] = time();
 			$_SESSION['qst']= 97;
-			//Give Reward 20 gold + 2 days plus
-			if(!$session->plus){
-				mysqli_query($database->dblink,"UPDATE ".TB_PREFIX."users set plus = ('".mktime(date("H"),date("i"), date("s"),date("m") , date("d"), date("Y"))."')+172800 where `username`='".$user_sanitized."'") or die(mysqli_error($database->dblink));
-			} else {
-				$plus=$database->getUserField($_SESSION['username'],'plus',1);
-				$plus+=172800;
-				$database->updateUserField($_SESSION['username'],'plus',$plus,0);
-			}
-			$gold=$database->getUserField($_SESSION['username'],'gold',1);
-			$gold+=20;
-			$database->updateUserField($_SESSION['username'],'gold',$gold,0);
 			break;
 		}
 	}


### PR DESCRIPTION
Fixes #129

## Problem
In the "no tasks" quest mode, claiming the first Plus + gold shipment
sometimes advances the UI to the next shipment countdown while the player
receives neither the Plus nor the gold. It is sporadic and hard to
reproduce on demand.

## Root cause
The shipment reward (case '91', and the final case '97') was granted with a
non-atomic read-modify-write — getUserField('gold') / $gold += 15 /
updateUserField('gold', $gold) — while the quest pointer and timer were
written unconditionally with literal values. The game fires many concurrent
ajax requests; one that read the gold/plus fields *before* the claim and
wrote the user row back *after* it silently clobbers the freshly granted
reward. The quest_time write (a literal) survives, so the UI advances while
the reward is lost — exactly the reported symptom, and exactly why it only
triggers under racy timing.

## Fix
- Gate the grant on an atomic conditional advance
  `UPDATE ... SET quest = 91 WHERE quest = 90`, granting the reward only when
  `mysqli_affected_rows() === 1`. The claim becomes idempotent —
  duplicate/concurrent requests grant nothing extra.
- Apply the reward with in-place SQL increments
  `gold = gold + 15, plus = IF(plus > now, plus + 86400, now + 86400)`, the
  same idiom already used in Templates/Plus/*.tpl. Immune to the lost-update
  race.
- Side benefit: an expired Plus timestamp is now reset to `now + ...` instead
  of being extended in the past.

Applied identically to quest_core.tpl and quest_core25.tpl.

## Testing
- Fresh account -> choose "skip" (no tasks) -> claim shipment 1: player
  reliably receives 15 gold + 1 day Plus, quest advances to the shipment-2
  countdown.
- Re-trigger the same claim (duplicate request): no extra reward, no error.
- Final shipment (case '97'): 20 gold + 2 days Plus, granted once.
- php -l clean on both templates.

## Scope note
Intermediate resource shipments (case '92'-'96') use modifyResource and only
grant resources, not Plus/gold; they are out of scope for this fix, which
targets the reported missing Plus/gold reward.