### PR TITLE
fix(i18n): localize statistics page and troops Hero label [#197]

### DIFF
--- a/GameEngine/Lang/en.php
+++ b/GameEngine/Lang/en.php
@@ -780,6 +780,9 @@ tz_def('AND', 'and');
 //other
 tz_def('VILLAGE', 'Village');
 tz_def('STATISTICS', 'Statistics');
+tz_def('ALLIANCES', 'Alliances');
+tz_def('HEROES', 'Heroes');
+tz_def('GENERAL', 'General');
 tz_def('OASIS', 'Oasis');
 tz_def('NO_OASIS', 'You do not own any oases.');
 tz_def('NO_VILLAGES', 'There are no villages.');

--- a/GameEngine/Lang/fr.php
+++ b/GameEngine/Lang/fr.php
@@ -776,6 +776,9 @@ define('AND', 'et');
 //other
 define('VILLAGE', 'Village');
 define('STATISTICS', 'Statistiques');
+define('ALLIANCES', 'Alliances');
+define('HEROES', 'Héros');
+define('GENERAL', 'Général');
 define('OASIS', 'Oasis');
 define('NO_OASIS', 'Vous ne possédez aucune oasis.');
 define('NO_VILLAGES', 'Il n\'y a pas de villages.');

--- a/GameEngine/Lang/ro.php
+++ b/GameEngine/Lang/ro.php
@@ -776,6 +776,9 @@ define('AND', 'și');
 //other
 define('VILLAGE', 'Sat');
 define('STATISTICS', 'Statistici');
+define('ALLIANCES', 'Alianțe');
+define('HEROES', 'Eroi');
+define('GENERAL', 'General');
 define('OASIS', 'Oază');
 define('NO_OASIS', 'Nu deții nicio oază.');
 define('NO_VILLAGES', 'Nu există sate.');

--- a/Templates/Ranking/ranksearch.tpl
+++ b/Templates/Ranking/ranksearch.tpl
@@ -31,12 +31,12 @@ if(!isset($_GET['id'])){ $_GET['id']='1'; }
 							<div class="navi">
 <?php
 if(count($rankArray) < 22){
-    echo "&laquo; back | forward &raquo;";
+    echo "&laquo; ".BACK." | ".FORWARD." &raquo;";
 }else if($start != 1 && $start + 20 < count($rankArray)) {
-    echo "<a href=\"statistiken.php?id=".$_GET['id']."&amp;rank=".($start - 20)."\">&laquo; back</a> | <a href=\"statistiken.php?id=".$_GET['id']."&amp;rank=".($start + 20)."\">forward &raquo;</a>";
+    echo "<a href=\"statistiken.php?id=".$_GET['id']."&amp;rank=".($start - 20)."\">&laquo; ".BACK."</a> | <a href=\"statistiken.php?id=".$_GET['id']."&amp;rank=".($start + 20)."\">".FORWARD." &raquo;</a>";
 }else if($start == 1 && $start + 20 < count($rankArray)) {
-    echo "&laquo; back | <a href=\"statistiken.php?id=".$_GET['id']."&amp;rank=".($start + 20)."\">forward &raquo;</a>";
+    echo "&laquo; ".BACK." | <a href=\"statistiken.php?id=".$_GET['id']."&amp;rank=".($start + 20)."\">".FORWARD." &raquo;</a>";
 }else if($start != 1 && $start - 20 < count($rankArray)) {
-    echo "<a href=\"statistiken.php?id=".$_GET['id']."&amp;rank=".($start - 20)."\">&laquo; back</a> | forward &raquo;";
+    echo "<a href=\"statistiken.php?id=".$_GET['id']."&amp;rank=".($start - 20)."\">&laquo; ".BACK."</a> | ".FORWARD." &raquo;";
 }
 ?>

--- a/Templates/troops.tpl
+++ b/Templates/troops.tpl
@@ -115,7 +115,7 @@ if (!empty($troops['hero'])) {
         </td>
 
         <td class="un">
-            Hero
+            ' . U0 . '
         </td>
     </tr>';
 

--- a/statistiken.php
+++ b/statistiken.php
@@ -35,24 +35,24 @@ if(isset($_GET['newdid'])) {
 <html>
 <head>
 	<title><?php
-	echo SERVER_NAME . ' &raquo; &raquo; &raquo; Statistics (';
+	echo SERVER_NAME . ' &raquo; &raquo; &raquo; ' . STATISTICS . ' (';
 
 	if (!empty($_GET['id'])) {
 	    switch ($_GET['id']) {
 	        case '4':
-	            echo 'Alliances';
+	            echo ALLIANCES;
 	            break;
 
 	        case '2':
-	            echo 'Villages';
+	            echo VILLAGES;
 	            break;
 
 	        case '8':
-	            echo 'Heroes';
+	            echo HEROES;
 	            break;
 
 	        case '0':
-	            echo 'General';
+	            echo GENERAL;
 	            break;
 
 	        case '99':
@@ -60,7 +60,7 @@ if(isset($_GET['newdid'])) {
 	            break;
 	    }
 	} else {
-	    echo 'Players';
+	    echo PLAYERS;
 	}
 
 	echo ')';
@@ -103,13 +103,13 @@ if(isset($_GET['newdid'])) {
 <div id="mid">
 <?php include("Templates/menu.tpl"); ?>
 		<div id="content"  class="statistics">
-<h1>Statistics</h1>
+<h1><?php echo STATISTICS; ?></h1>
 <div id="textmenu">
-   <a href="statistiken.php" <?php if(!isset($_GET['id']) || (isset($_GET['id']) && ($_GET['id'] == 1 || $_GET['id'] == 31 || $_GET['id'] == 32 || $_GET['id'] == 7))) { echo "class=\"selected \""; } ?>>Player</a>
- | <a href="statistiken.php?id=4" <?php if(isset($_GET['id']) && ($_GET['id'] == 4 || $_GET['id'] == 41 || $_GET['id'] == 42 || $_GET['id'] == 43)) { echo "class=\"selected \""; } ?>>Alliances</a>
- | <a href="statistiken.php?id=2" <?php if(isset($_GET['id']) && $_GET['id'] == 2) { echo "class=\"selected \""; } ?>>Villages</a>
- | <a href="statistiken.php?id=8" <?php if(isset($_GET['id']) && $_GET['id'] == 8) { echo "class=\"selected \""; } ?>>Heroes</a>
- | <a href="statistiken.php?id=0" <?php if(isset($_GET['id']) && $_GET['id'] == 0) { echo "class=\"selected \""; } ?>>General</a>
+   <a href="statistiken.php" <?php if(!isset($_GET['id']) || (isset($_GET['id']) && ($_GET['id'] == 1 || $_GET['id'] == 31 || $_GET['id'] == 32 || $_GET['id'] == 7))) { echo "class=\"selected \""; } ?>><?php echo PLAYER; ?></a>
+ | <a href="statistiken.php?id=4" <?php if(isset($_GET['id']) && ($_GET['id'] == 4 || $_GET['id'] == 41 || $_GET['id'] == 42 || $_GET['id'] == 43)) { echo "class=\"selected \""; } ?>><?php echo ALLIANCES; ?></a>
+ | <a href="statistiken.php?id=2" <?php if(isset($_GET['id']) && $_GET['id'] == 2) { echo "class=\"selected \""; } ?>><?php echo VILLAGES; ?></a>
+ | <a href="statistiken.php?id=8" <?php if(isset($_GET['id']) && $_GET['id'] == 8) { echo "class=\"selected \""; } ?>><?php echo HEROES; ?></a>
+ | <a href="statistiken.php?id=0" <?php if(isset($_GET['id']) && $_GET['id'] == 0) { echo "class=\"selected \""; } ?>><?php echo GENERAL; ?></a>
  <?php if(WW == true) { echo
  '|'; } else { echo ''; } ?> <a href="statistiken.php?id=99" <?php if(isset($_GET['id']) && $_GET['id'] == 99) { echo "class=\"selected \""; } ?>><?php if(WW == true) { echo
  'WW'; } else { echo ''; }?></a>


### PR DESCRIPTION
## What

Fixes #197 — on a fresh install several strings were still hardcoded in
English (reported on the live server, RO locale).

- `statistiken.php`: the page `<title>`, the `<h1>` and the ranking tab bar
  (Player / Alliances / Villages / Heroes / General) were literal English.
- `Templates/Ranking/ranksearch.tpl`: the `back | forward` pagination links.
- `Templates/troops.tpl`: the `Hero` troop-row label.

## How

Wire these strings to language constants. Reuse existing ones
(`STATISTICS`, `PLAYER`, `PLAYERS`, `VILLAGES`, `BACK`, `FORWARD`, `U0`) and add
three new constants (`ALLIANCES`, `HEROES`, `GENERAL`) to `en`/`fr`/`ro`.
`WW` is kept as-is (universal acronym).

## Testing

- `php -l` clean on all changed files.
- Verified in-game (RO/FR): the statistics tabs/title/pagination and the
  Hero label now render translated.