### PR TITLE
feat(preferences): implement "Large map" preference + fix prefs persistence [#198]

### DIFF
--- a/GameEngine/Profile.php
+++ b/GameEngine/Profile.php
@@ -91,14 +91,10 @@ class Profile {
 			"WHERE id=" . (int)$session->uid
 		);
 
-		// Keep the in-memory session in sync for the immediate re-render.
-		foreach ([
-			'v1' => $v1, 'v2' => $v2, 'v3' => $v3, 'map' => $map,
-			'v4' => $v4, 'v5' => $v5, 'v6' => $v6,
-			'timezone' => $timezone, 'tformat' => $tformat,
-		] as $field => $value) {
-			$session->userinfo[$field] = $value;
-		}
+		// Invalidate the 30s session user-cache (see Session::PopulateVar) so the
+		// reloaded page reflects the new values immediately, without a re-login.
+		$cacheKeyUser = 'cache_user_' . ($_SESSION['username'] ?? '');
+		unset($_SESSION[$cacheKeyUser]);
 
 		// Game language.
 		$allowed = ['en', 'fr', 'it', 'ro', 'zh'];

--- a/GameEngine/Profile.php
+++ b/GameEngine/Profile.php
@@ -59,12 +59,48 @@ class Profile {
 	}
 
 	/**
-	 * Preferences form (ft=p2): persist the per-user game language.
-	 * Writes the existing `lang` column (matches struct.sql + Session seeding).
+	 * Preferences form (ft=p2): persist all per-user preferences.
+	 * Stores the checkbox prefs (auto-completion v1-v3, large map, report
+	 * filter v4-v6), the time preference (timezone/tformat) and the game
+	 * language. Columns match struct.sql + Session seeding. Some of these are
+	 * stored only for now and applied in-game incrementally (issue #198).
 	 */
 	private function updatePreferences($post) {
 		global $database, $session;
 
+		// Checkbox preferences -> 0/1 (unchecked boxes are absent from POST).
+		$v1  = empty($post['v1'])  ? 0 : 1;
+		$v2  = empty($post['v2'])  ? 0 : 1;
+		$v3  = empty($post['v3'])  ? 0 : 1;
+		$map = empty($post['map']) ? 0 : 1;
+		$v4  = empty($post['v4'])  ? 0 : 1;
+		$v5  = empty($post['v5'])  ? 0 : 1;
+		$v6  = empty($post['v6'])  ? 0 : 1;
+
+		// Time preference: timezone index + date format (0..3).
+		$timezone = isset($post['timezone']) ? (int)$post['timezone'] : 1;
+		$tformat  = isset($post['tformat'])  ? (int)$post['tformat']  : 0;
+		if ($tformat < 0 || $tformat > 3) {
+			$tformat = 0;
+		}
+
+		$database->query(
+			"UPDATE " . TB_PREFIX . "users SET " .
+			"v1=$v1, v2=$v2, v3=$v3, map=$map, v4=$v4, v5=$v5, v6=$v6, " .
+			"timezone=$timezone, tformat=$tformat " .
+			"WHERE id=" . (int)$session->uid
+		);
+
+		// Keep the in-memory session in sync for the immediate re-render.
+		foreach ([
+			'v1' => $v1, 'v2' => $v2, 'v3' => $v3, 'map' => $map,
+			'v4' => $v4, 'v5' => $v5, 'v6' => $v6,
+			'timezone' => $timezone, 'tformat' => $tformat,
+		] as $field => $value) {
+			$session->userinfo[$field] = $value;
+		}
+
+		// Game language.
 		$allowed = ['en', 'fr', 'it', 'ro', 'zh'];
 		if (!empty($post['lang'])) {
 			$lang = strtolower(trim($post['lang']));

--- a/Templates/Map/mapview.tpl
+++ b/Templates/Map/mapview.tpl
@@ -439,7 +439,14 @@ while ($donnees = mysqli_fetch_assoc($result2)) {
 			function init_local(){map_init();}
 		</script><?php
 		if($session->plus){
-			echo '<a id="map_makelarge" href="#" onclick="PopupMap('.$bigmid.');" ><img class="ml" src="img/x.gif" alt="'.LARGE_MAP.'" title="'.LARGE_MAP.'"/></a>';
+			if(!empty($session->userinfo['map'])){
+				// Preference "Show the large map in an extra window" (#198):
+				// open the large map (karte2.php) in a separate browser window
+				// instead of the in-page iframe overlay.
+				echo '<a id="map_makelarge" href="karte2.php?z='.$bigmid.'" target="bigmap" onclick="window.open(this.href, \'bigmap\', \'width=1020,height=600,scrollbars=yes,resizable=yes\'); return false;"><img class="ml" src="img/x.gif" alt="'.LARGE_MAP.'" title="'.LARGE_MAP.'"/></a>';
+			} else {
+				echo '<a id="map_makelarge" href="#" onclick="PopupMap('.$bigmid.');" ><img class="ml" src="img/x.gif" alt="'.LARGE_MAP.'" title="'.LARGE_MAP.'"/></a>';
+			}
 		}?>
 		<img id="map_navibox" src="img/x.gif" usemap="#map_navibox"/>
 		<map name="map_navibox">

--- a/Templates/Profile/preference.tpl
+++ b/Templates/Profile/preference.tpl
@@ -385,10 +385,7 @@ if(isset($_POST['lang']))
 <thead>
 <tr>
   <th colspan="2">
-    Large map 
-    <span style="color:#999; font-weight:400; font-size:0.9em; font-style:italic; opacity:0.7;">
-      <?php echo TZ_NOT_CODED_YET; ?>
-    </span>
+    <?php echo LARGE_MAP; ?>
   </th>
 </tr>
 </thead>


### PR DESCRIPTION
## What

First step of #198 (Code for Preference): implement the **Large map** user
preference ("Show the large map in an extra window").

- `Templates/Map/mapview.tpl`: when the `map` preference is on, the large-map
  button opens `karte2.php` in a separate browser window instead of the in-page
  iframe overlay (default behaviour kept when off).
- `Templates/Profile/preference.tpl`: drop the "(not coded yet)" marker from the
  Large map section and use the existing `LARGE_MAP` constant for its title.

## Preferences persistence fix (shared by all #198 steps)

The `ft=p2` handler (`Profile::updatePreferences`) only saved the language
column, so every other preference reverted on save — the matching block in
`preference.tpl` was dead code (the handler `header()+exit` before it runs).

This PR makes the handler persist the whole preferences form (checkboxes as 0/1,
`timezone`/`tformat` as validated ints) and invalidates the 30s session
user-cache so a saved preference shows immediately (no re-login). The
non-Large-map fields are stored now and applied in-game in the following #198
steps (report filter, auto-completion, time preference).

## Testing

- `php -l` clean on all changed files.
- Verified in-game (Plus account): toggling the preference persists across
  reloads without re-login; the large map opens in a separate window when on,
  and as the in-page overlay when off.