### PR TITLE
feat(preferences): apply report filter (suppress merchant-transfer reports) [#198]

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -641,8 +641,17 @@ class Automation {
             $ownally = $userData_from['alliance'];
             $targetally = $userData_to['alliance'];
 
-            $database->addNotice($to['owner'],$to['wref'],$targetally,$sort_type,''.addslashes($from['name']).' send resources to '.addslashes($to['name']).'',''.$from['owner'].','.$from['wref'].','.$data['wood'].','.$data['clay'].','.$data['iron'].','.$data['crop'].'',$data['endtime']);
-            if($from['owner'] != $to['owner']) {
+            // Report filter preferences (#198): skip merchant-transfer notices
+            // according to the saved checkboxes of the involved players.
+            //   v4 -> recipient: no report for transfers to own villages
+            //   v6 -> recipient: no report for transfers from foreign villages
+            //   v5 -> sender:    no report for transfers to foreign villages
+            $ownTransfer   = ($from['owner'] == $to['owner']);
+            $skipRecipient = $ownTransfer ? !empty($userData_to['v4']) : !empty($userData_to['v6']);
+            if(!$skipRecipient) {
+                $database->addNotice($to['owner'],$to['wref'],$targetally,$sort_type,''.addslashes($from['name']).' send resources to '.addslashes($to['name']).'',''.$from['owner'].','.$from['wref'].','.$data['wood'].','.$data['clay'].','.$data['iron'].','.$data['crop'].'',$data['endtime']);
+            }
+            if(!$ownTransfer && empty($userData_from['v5'])) {
                 $database->addNotice($from['owner'],$to['wref'],$ownally,$sort_type,''.addslashes($from['name']).' send resources to '.addslashes($to['name']).'',''.$from['owner'].','.$from['wref'].','.$data['wood'].','.$data['clay'].','.$data['iron'].','.$data['crop'].'',$data['endtime']);
             }
             $database->modifyResource($data['to'],$data['wood'],$data['clay'],$data['iron'],$data['crop'],1);

--- a/Templates/Profile/preference.tpl
+++ b/Templates/Profile/preference.tpl
@@ -406,10 +406,7 @@ if(isset($_POST['lang']))
 <thead>
 <tr>
   <th colspan="2">
-    Report filter
-    <span style="color:#999; font-weight:400; font-size:0.9em; font-style:italic; opacity:0.7;">
-      <?php echo TZ_NOT_CODED_YET; ?>
-    </span>
+    <?php echo REPORT_FILTER; ?>
   </th>
 </tr>
 </thead>


### PR DESCRIPTION
## What

Implements the **Report filter** section of the player preferences (issue #198),
which until now was stored in DB but never applied in-game (tagged "not coded yet").

The three per-user checkboxes now suppress the corresponding merchant-transfer
notices when a shipment is delivered in `Automation::marketComplete()`:

| Pref | Who | Effect |
|------|-----|--------|
| `v4` | recipient | no report for transfers **to own villages** (same owner) |
| `v6` | recipient | no report for transfers **from foreign villages** |
| `v5` | sender    | no report for transfers **to foreign villages** |

With every box unchecked the behaviour is identical to before.

## How

- `GameEngine/Automation.php` — in `marketComplete()`, the recipient and sender
  `addNotice()` calls are now gated by the involved player's preference. The user
  row is already fully loaded by `getUserFields()`, so the flags are read without
  any extra query. Trade-route deliveries use the same path and are filtered too.
- `Templates/Profile/preference.tpl` — removed the "not coded yet" tag from the
  Report filter section and switched the hard-coded title to the existing
  `REPORT_FILTER` constant (already translated EN/FR/RO).

## Testing

- PHP lint clean on both files.
- Verified in-game: with each box checked the matching merchant report is
  suppressed (own-village transfer, send to foreign, receive from foreign), and
  unchecked boxes still produce the reports as before.
