### PR TITLE
feat(preferences): apply auto-completion (village name suggestions) [#198]

### DIFF
--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -5377,6 +5377,67 @@ $q = "INSERT INTO ".TB_PREFIX."demolition VALUES (
         return $this->getVillage($name, 1, $use_cache)['wref'];
 	}
 
+	/**
+	 * Build the village-name autocomplete suggestions for the rally point and
+	 * the marketplace, honouring the player's auto-completion preferences
+	 * (issue #198):
+	 *   v1 -> own villages
+	 *   v2 -> villages in the surroundings of the active village
+	 *   v3 -> villages of the player's alliance members
+	 * System accounts (Nature, Natars, Multihunter, ...) are excluded.
+	 *
+	 * @param int $uid      Player id (own villages / self).
+	 * @param int $alliance Player's alliance id (0 = none).
+	 * @param int $x        Active village X coordinate (vicinity center).
+	 * @param int $y        Active village Y coordinate (vicinity center).
+	 * @param bool $v1      Include own villages.
+	 * @param bool $v2      Include surrounding villages.
+	 * @param bool $v3      Include alliance villages.
+	 * @param int $radius   Vicinity radius in fields (v2).
+	 * @param int $limit    Max number of names returned.
+	 * @return string[]     Distinct village names.
+	 */
+	function getAutoCompleteVillages($uid, $alliance, $x, $y, $v1, $v2, $v3, $radius = 25, $limit = 100) {
+		$uid      = (int) $uid;
+		$alliance = (int) $alliance;
+		$x        = (int) $x;
+		$y        = (int) $y;
+		$radius   = (int) $radius;
+		$limit    = (int) $limit;
+
+		$joins = "JOIN " . TB_PREFIX . "users u ON u.id = v.owner ";
+		$conds = [];
+
+		if ($v1) {
+			$conds[] = "v.owner = $uid";
+		}
+		if ($v3 && $alliance > 0) {
+			$conds[] = "u.alliance = $alliance";
+		}
+		if ($v2) {
+			$joins  .= "JOIN " . TB_PREFIX . "wdata w ON w.id = v.wref ";
+			$conds[] = "(ABS(w.x - $x) <= $radius AND ABS(w.y - $y) <= $radius)";
+		}
+
+		if (!count($conds)) {
+			return [];
+		}
+
+		$q = "SELECT DISTINCT v.name FROM " . TB_PREFIX . "vdata v " .
+			$joins .
+			"WHERE u.id > 5 AND (" . implode(' OR ', $conds) . ") " .
+			"ORDER BY v.name LIMIT $limit";
+
+		$result = mysqli_query($this->dblink, $q);
+		$names  = [];
+		if ($result) {
+			while ($row = mysqli_fetch_assoc($result)) {
+				$names[] = $row['name'];
+			}
+		}
+		return $names;
+	}
+
     function getVillageByOwner($uid, $use_cache = true) {
         $uid = (int) $uid;
 

--- a/Templates/Build/17.tpl
+++ b/Templates/Build/17.tpl
@@ -134,7 +134,7 @@ if (isset($_GET['z'])) {
 
         <table id="target_select" class="res_target" cellpadding="1" cellspacing="1">
             <tr><td class="mer"><?php echo MERCHANT;?> <?php echo $merchantAvail;?>/<?php echo $totalMerchants;?></td></tr>
-            <tr><td class="vil"><span><?php echo VILLAGES;?>:</span> <input class="text" type="text" name="dname" value="" maxlength="30" tabindex="5"></td></tr>
+            <tr><td class="vil"><span><?php echo VILLAGES;?>:</span> <input class="text" type="text" name="dname" value="" maxlength="30" tabindex="5" list="dnameSuggest" autocomplete="off"><?php include("Templates/villageAutocomplete.tpl"); ?></td></tr>
             <tr><td class="or"><?php echo OR_;?></td></tr>
             <tr>
                 <td class="coo">

--- a/Templates/Profile/preference.tpl
+++ b/Templates/Profile/preference.tpl
@@ -350,10 +350,7 @@ if(isset($_POST['lang']))
 <thead>
 <tr>
   <th colspan="2">
-    Auto completion 
-    <span style="color:#999; font-weight:400; font-size:0.9em; font-style:italic; opacity:0.7;">
-      <?php echo TZ_NOT_CODED_YET; ?>
-    </span>
+    <?php echo AUTO_COMPL; ?>
   </th>
 </tr>
 <tr><td colspan="2"><?php echo TZ_USED_FOR_RALLY_POINT_AND_MARKETPLA; ?></td></tr>

--- a/Templates/a2b/search.tpl
+++ b/Templates/a2b/search.tpl
@@ -44,7 +44,8 @@ if (isset($_GET['z'])) {
             </td>
             <td class="vil">
                 <span><?php echo TZ_VILLAGE; ?></span>
-                <input class="text" name="dname" value="<?php echo htmlspecialchars($form->getValue('dname'), ENT_QUOTES); ?>" maxlength="20" type="text">
+                <input class="text" name="dname" value="<?php echo htmlspecialchars($form->getValue('dname'), ENT_QUOTES); ?>" maxlength="20" type="text" list="dnameSuggest" autocomplete="off">
+                <?php include("Templates/villageAutocomplete.tpl"); ?>
             </td>
         </tr>
         <tr>

--- a/Templates/villageAutocomplete.tpl
+++ b/Templates/villageAutocomplete.tpl
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Village-name autocomplete datalist for the rally point and the marketplace.
+ * Honours the player's auto-completion preferences (issue #198): v1 own
+ * villages, v2 surrounding villages, v3 alliance villages. Renders a
+ * <datalist id="dnameSuggest"> consumed by the dname input via
+ * list="dnameSuggest". Nothing is emitted when every box is unchecked.
+ */
+global $database, $session, $village;
+
+$acV1 = !empty($session->userinfo['v1']);
+$acV2 = !empty($session->userinfo['v2']);
+$acV3 = !empty($session->userinfo['v3']);
+
+if ($acV1 || $acV2 || $acV3) {
+    $acNames = $database->getAutoCompleteVillages(
+        $session->uid,
+        $session->alliance,
+        $village->coor['x'] ?? 0,
+        $village->coor['y'] ?? 0,
+        $acV1,
+        $acV2,
+        $acV3
+    );
+
+    echo '<datalist id="dnameSuggest">';
+    foreach ($acNames as $acName) {
+        echo '<option value="' . htmlspecialchars($acName, ENT_QUOTES) . '">';
+    }
+    echo '</datalist>';
+}
+?>


### PR DESCRIPTION
## What

Implements the **Auto completion** section of the player preferences (issue #198),
which until now was stored in DB but never applied in-game (tagged "not coded yet").

On the **rally point** and the **marketplace** the target village can be typed by
name (`dname` field). The three per-user checkboxes now drive native village-name
suggestions for that field:

| Pref | Suggests |
|------|----------|
| `v1` | own villages |
| `v2` | villages in the surroundings of the active village |
| `v3` | villages of the player's alliance members |

With every box unchecked, no suggestions are emitted and the behaviour is
identical to before.

## How

- `GameEngine/Database.php` — new `getAutoCompleteVillages()` builds the bounded
  (LIMIT 100), de-duplicated village-name list from the enabled categories in a
  single query. System accounts (Nature, Natars, Multihunter, ...) are excluded;
  `v2` is bounded by a 25-field radius around the active village.
- `Templates/villageAutocomplete.tpl` — shared partial rendering a native
  `<datalist id="dnameSuggest">`; nothing is output when all boxes are unchecked.
- `Templates/a2b/search.tpl` & `Templates/Build/17.tpl` — the `dname` input is
  wired to the datalist via `list="dnameSuggest"`.
- `Templates/Profile/preference.tpl` — removed the "not coded yet" tag and
  switched the hard-coded title to the existing `AUTO_COMPL` constant (already
  translated EN/FR/RO).

No new UI strings: every constant already existed in all three language files.

## Testing

- PHP lint clean on all touched files.
- Verified in-game: suggestions appear on the rally point and marketplace village
  field according to the checked categories (own / surroundings / alliance);
  selecting a suggestion and sending works; with all boxes unchecked no
  suggestions appear and the field behaves as before.