### PR TITLE
fix(report): restore combat report layout and silence PHP 8 warnings [#203]

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -1842,7 +1842,7 @@ class Automation {
 
                     //type of attack
                     $type = $dataarray[$data_num]['attack_type'];
-                    if($type == 1) $scout = 1;
+                    $scout = ($type == 1) ? 1 : 0;
                     
                     $ud = ($def_tribe - 1) * 10;
                     $att_ab = $database->getABTech($data['from']); // Blacksmith level
@@ -1941,7 +1941,7 @@ class Automation {
 
                     //type of attack
                     $type = $dataarray[$data_num]['attack_type'];
-                    if($type == 1) $scout = 1;
+                    $scout = ($type == 1) ? 1 : 0;
 
                     $att_ab1 = $att_ab2 = $att_ab3 = $att_ab4 = $att_ab5 = $att_ab6 = $att_ab7 = $att_ab8 = 0;
                     $def_ab[31] = $def_ab[32] = $def_ab[33] = $def_ab[34] = $def_ab[35] = $def_ab[36] = $def_ab[37] = $def_ab[38] = 0;
@@ -2082,7 +2082,7 @@ class Automation {
                     $info_cat = $info_chief = $info_ram = $info_hero = ",";
                     
                     //check to see if can destroy village
-                    if (count($varray) > 1 && !$database->villageHasArtefact($DefenderWref) && !$to['natar']) {
+                    if (count($varray) > 1 && !$database->villageHasArtefact($DefenderWref) && empty($to['natar'])) {
                     	$can_destroy = 1;
                     }
                     else $can_destroy = 0;

--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -1629,7 +1629,7 @@ class Automation {
                     .','.$unitssend_def[4].','.$unitsdead_def[4].','.$natar
                     .','.$unitssend_def[5].','.$unitsdead_def[5]
                     .','.$DefenderHeroesTot.','.$DefenderHeroesDead
-                    .','.$info_ram.','.$info_cat.','.$info_chief.'.'.(isset($info_spy) ? $info_spy : '')
+                    .','.$info_ram.','.$info_cat.','.$info_chief.','.(isset($info_spy) ? $info_spy : '')
                     .',,'.$data['t11'].','.$dead11.','.$herosend_def.','.$deadhero
                     .','.$unitstraped_att;
 

--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -6130,12 +6130,12 @@ $q = "INSERT INTO ".TB_PREFIX."demolition VALUES (
         $end              = ( $ownertribe * 10 );
 
         for ( $i = $start; $i <= $end; $i ++ ) {
-            $totalunits += $movingunits[ 'u' . $i ];
-            $totalunits += $reinforcingunits[ 'u' . $i ];
+            $totalunits += $movingunits[ 'u' . $i ] ?? 0;
+            $totalunits += $reinforcingunits[ 'u' . $i ] ?? 0;
         }
 
-        $totalunits += $movingunits['hero'];
-        $totalunits += $reinforcingunits['hero'];
+        $totalunits += $movingunits['hero'] ?? 0;
+        $totalunits += $reinforcingunits['hero'] ?? 0;
 
 		return $totalunits;
 	}

--- a/Templates/Notice/1.tpl
+++ b/Templates/Notice/1.tpl
@@ -144,7 +144,9 @@ if ($hasHero) {
 }
 
 // PRISONERS (unchanged logic but safer sum)
-if (!$spy && array_sum(array_slice($dataarray, 182, 11)) > 0) {
+// Cast to int: some reports carry non-numeric text in these slots (e.g. the
+// "Information" line shifts indices), which made array_sum() warn under PHP 8.
+if (!$spy && array_sum(array_map('intval', array_slice($dataarray, 182, 11))) > 0) {
     echo "</tr><tr><th>".PRISONERS."</th>";
 
     for ($i = 182; $i <= 191; $i++) {


### PR DESCRIPTION
## What

Attacking and viewing combat reports rendered a broken report (misplaced
hero/prisoner data) and flooded the error log with PHP 8 warnings.

## Root cause

The #155 refactor that extracted `buildCombatReport()` turned one comma
into a literal dot in the non-scout `data2` string:

    ...$info_chief.'.'.(isset($info_spy) ? ...   // was ','

That dropped one CSV field, shifting every following field left by one
(hero troops `t11`, casualties, prisoners 182-192) and injecting a stray
`.` into a numeric cell. The shifted text landing in the prisoner slots
is also what made `Templates/Notice/1.tpl` `array_sum()` warn under PHP 8.

## Changes

- **`Automation.php`** — restore the comma in `data2` so the layout matches
  the pre-refactor code and what `Notice/1.tpl` expects.
- **`Templates/Notice/1.tpl`** — int-cast the prisoner slots before
  `array_sum()`. Reports stored before the fix keep their corrupted string;
  this keeps them from re-emitting "Addition is not supported on type string".
- **`Automation.php`** — initialize `$scout` for every attack type (it was
  only defined for scouting, yet always passed to `buildCombatReport()`),
  and use `empty($to['natar'])` for the destroy-village check.
- **`Database.php`** — null-coalesce movement/reinforcement unit and hero
  reads in `getUnitsNumber()` (arrays can be null or miss tribe keys).

Pure null-safety / layout-restoring changes; no gameplay logic altered.

## Testing

- PHP lint clean on all touched files.
- Verified in-game: a fresh attack report now renders troops/casualties/hero
  correctly with the right "Information" line, and the Apache error log stays
  free of these warnings.
  
  
<img width="520" height="429" alt="image" src="https://github.com/user-attachments/assets/e636f30c-ebb2-4f41-9eb7-25670e12f0f3" />
