### PR TITLE
fix(market): raise resource input maxlength so high-speed servers can send full convoys

### DIFF
--- a/Templates/Build/17.tpl
+++ b/Templates/Build/17.tpl
@@ -126,7 +126,7 @@ if (isset($_GET['z'])) {
             <tr>
                 <td class="ico"><a href="#" onClick="upd_res(<?php echo $i;?>,1); return false;"><img class="r<?php echo $i;?>" src="img/x.gif" alt="<?php echo $resNames[$i];?>" title="<?php echo $resNames[$i];?>" /></a></td>
                 <td class="nam"><?php echo $resNames[$i];?>:</td>
-                <td class="val"><input class="text" type="text" name="r<?php echo $i;?>" id="r<?php echo $i;?>" value="" maxlength="5" onKeyUp="upd_res(<?php echo $i;?>)" tabindex="<?php echo $i;?>"></td>
+                <td class="val"><input class="text" type="text" name="r<?php echo $i;?>" id="r<?php echo $i;?>" value="" maxlength="9" onKeyUp="upd_res(<?php echo $i;?>)" tabindex="<?php echo $i;?>"></td>
                 <td class="max"><a href="#" onMouseUp="add_res(<?php echo $i;?>);" onClick="return false;">(<?php echo $maxcarry;?>)</a></td>
             </tr>
             <?php endfor;?>

--- a/Templates/Build/17_create.tpl
+++ b/Templates/Build/17_create.tpl
@@ -38,7 +38,7 @@ $firstSelect = ($villages[0]?? 0) == $village->wid? 1 : 0;
                         <?php $icons = [1=>'1',2=>'2',3=>'3',4=>'4']; $names = [1=>LUMBER,2=>CLAY,3=>IRON,4=>CROP];
                         foreach ($icons as $i => $img):?>
                             <img src="../../<?php echo GP_LOCATE;?>img/r/<?php echo $img;?>.gif" alt="<?php echo $names[$i];?>" title="<?php echo $names[$i];?>">
-                            <input class="text" type="text" name="r<?php echo $i;?>" id="r<?php echo $i;?>" value="" maxlength="5" tabindex="1" style="width:50px;">
+                            <input class="text" type="text" name="r<?php echo $i;?>" id="r<?php echo $i;?>" value="" maxlength="9" tabindex="1" style="width:50px;">
                         <?php endforeach;?>
                     </td>
                 </tr>

--- a/Templates/Build/17_edit.tpl
+++ b/Templates/Build/17_edit.tpl
@@ -32,7 +32,7 @@ $deliveries = (int)($edited_route['deliveries']??1);
                         ];
                         foreach ($res as $r):?>
                             <img src="../../<?php echo GP_LOCATE;?>img/r/<?php echo $r[2];?>.gif" alt="<?php echo $r[3];?>" title="<?php echo $r[3];?>">
-                            <input class="text" type="text" name="<?php echo $r[0];?>" id="<?php echo $r[0];?>" value="<?php echo $r[1];?>" maxlength="5" tabindex="1" style="width:50px;">
+                            <input class="text" type="text" name="<?php echo $r[0];?>" id="<?php echo $r[0];?>" value="<?php echo $r[1];?>" maxlength="9" tabindex="1" style="width:50px;">
                         <?php endforeach;?>
                     </td>
                 </tr>


### PR DESCRIPTION
## What

Raises the `maxlength` on the marketplace resource input fields from `5` to `9`.

## Why

The send/trade-route resource fields were capped at `maxlength="5"`, limiting
input to **99,999 per resource**. On high-speed servers a single merchant convoy
carries far more than that (e.g. Teutons: 1000 × server speed = 500,000 on a
500x server, and up to 1,500,000 with a Trade Office), so players simply could
not type enough to fill their merchants.

`maxlength="9"` (~1 billion) covers any server speed while keeping a sane bound,
consistent with the other inputs on the page.

## Scope

Three templates of the Marketplace (building 17):

- `Templates/Build/17.tpl` — send resources
- `Templates/Build/17_create.tpl` — create trade route
- `Templates/Build/17_edit.tpl` — edit trade route

## Notes

- **No server-side change needed.** `Market::sendResource()` already validates
  against available resources (`TOO_FEW_RESOURCES`) and merchant capacity
  (`TOO_FEW_MERCHANTS`), so no over-send is possible — the larger input only
  removes the artificial typing cap.
- Pure HTML attribute change, no logic touched.