### PR TITLE
Fix(farmlist): raid bugs and PHP 8.3 warnings

### DIFF
--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -8003,7 +8003,7 @@ $q = "INSERT INTO ".TB_PREFIX."demolition VALUES (
 		$q = 'SELECT * FROM ' . TB_PREFIX . 'farmlist WHERE owner = '.$uid.' ORDER BY wref ASC LIMIT 1';
 		$result = mysqli_query($this->dblink,$q);
 		$dbarray = mysqli_fetch_array($result);
-		return $dbarray['id'] > 0;
+		return ($dbarray['id'] ?? 0) > 0;
 	}
 
     // no need to cache this method

--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -2744,7 +2744,7 @@ class MYSQLi_DB implements IDbConnection {
 		return mysqli_query($this->dblink,$q);
 	}
 
-	function getVillageType2($wref) {
+	function getVillageType2($wref, $use_cache = true) {
         // retirieve form cache
         return $this->getVillageByWorldID($wref, $use_cache)['oasistype'];
 	}

--- a/GameEngine/Units.php
+++ b/GameEngine/Units.php
@@ -761,7 +761,7 @@ class Units {
     public function startRaidList($post){   
     	global $database, $generator, $session;
 
-    	$slots = $post['slot'];
+    	$slots = $post['slot'] ?? [];
     	if(empty($slots)){
     		header("Location: build.php?id=39&t=99");
     		exit();

--- a/Templates/goldClub/farmlist.tpl
+++ b/Templates/goldClub/farmlist.tpl
@@ -259,7 +259,7 @@ if (mysqli_num_rows($getnotice) > 0) {
 <?php if ($database->getVilFarmlist($session->uid)) { ?>
 
 <div class="markAll">
-    <input type="checkbox" onclick="Allmsg(this.form);">
+    <input class="check" type="checkbox" id="s10" name="s10" onclick="Allmsg(this.form);">
     <label><?php echo TZ_SELECT_ALL; ?></label>
 </div>
 

--- a/Templates/goldClub/farmlist_editraid.tpl
+++ b/Templates/goldClub/farmlist_editraid.tpl
@@ -8,7 +8,7 @@ $errormsg = $errormsg ?? null;
 /* =====================================================
    LOAD SLOT DATA (EDIT MODE)
 ===================================================== */
-if ($action === 'editSlot' && $eid) {
+if ($action === 'showSlot' && $eid) {
 
     $eiddata = $database->getRaidList($eid);
 
@@ -192,7 +192,7 @@ if (
                             $lname = $row["name"];
                             $lvname = $database->getVillageField($row["wref"], 'name');
 
-                            $selected = ($lid == $lid2) ? 'selected' : '';
+                            $selected = ($lid == ($eiddata['lid'] ?? 0)) ? 'selected' : '';
 
                             echo '<option value="'.$lid.'" '.$selected.'>'
                                 .$lvname.' - '.$lname.


### PR DESCRIPTION
Fixes a set of farmlist/raid bugs and PHP 8.3 warnings found via player error
logging. Each is a small, behaviour-preserving change.

- **getVillageType2()** (Database.php): referenced an undefined `$use_cache`,
  silently passed as `null` to `getVillageByWorldID()` — this disabled the cache
  on every call and emitted "Undefined variable $use_cache" warnings (the most
  frequent one). Added `$use_cache = true` to the signature.
- **"Select all" checkbox** (farmlist.tpl): the checkbox called `Allmsg(this.form)`
  but, unlike every other usage (Message inbox/archive/sent, Notice), it had no
  `name="s10"`. `Allmsg()` reads `document.msg.s10.checked`, so it threw a JS
  error and nothing got selected. Added `id`/`name="s10"`.
- **getVilFarmlist()** (Database.php): "access array offset on null" when the
  player has no farmlist; guarded with `($dbarray['id'] ?? 0) > 0`.
- **startRaidList()** (Units.php): "Undefined array key 'slot'" when starting a
  raid with nothing selected; defaulted to `$post['slot'] ?? []`.
- **Edit raid** (farmlist_editraid.tpl): the slot data was only loaded on
  `action=editSlot`, but the editor opens via `action=showSlot` (the EDIT link
  and the form URL). So `$eiddata` was never loaded on display: empty form,
  dropdown not pre-selected (`$lid2` was never defined), broken Delete button.
  Now loads on `showSlot` (saving is the separate POST `editSlot` block, which
  redirects) and pre-selects with `$eiddata['lid']`.

Tested in-game: farmlist listing, "select all", raid editing/saving/deleting all
work, and the player debug log is now clean.