### PR TITLE
Fix(market): restore "max per merchant" click in send-resources tab

### DIFF
--- a/Templates/Build/17.tpl
+++ b/Templates/Build/17.tpl
@@ -69,7 +69,9 @@ if (isset($_GET['z'])) {
     <?php include("17_menu.tpl");?>
 
     <script language="JavaScript">
-    
+    // Globals used by add_res()/upd_res() in unx.js for the "max per merchant" click.
+    var haendler = <?php echo $merchantAvail; ?>;
+    var carry = <?php echo $maxcarry; ?>;
     </script>
 
 <?php if ($showConfirm && $target):?>


### PR DESCRIPTION
The marketplace send tab (`Templates/Build/17.tpl`) was refactored with an
empty `<script>` block, which dropped the `haendler` (available merchants) and
`carry` (per-merchant capacity) globals that `add_res()` / `upd_res()` in
`unx.js` rely on. Without them `ic = haendler * carry` evaluates to NaN, so
clicking the "(capacity)" link next to a resource (or the resource icon) no
longer fills the input.

Restore the two globals so the max-per-merchant fill works again. The rest of
the infrastructure (`fb`, the `l1..l4` stock trackers registered by `mb()` on
load) was already intact.