### PR TITLE
Perf: cache zero building levels in getFieldLevelInVillage [#155]

### DIFF
--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -3729,9 +3729,12 @@ class MYSQLi_DB implements IDbConnection {
         $vid = (int) $vid;
 
         // first of all, check if we should be using cache and whether the field
-        // required is already cached
-        if ($use_cache && ($cachedValue = self::returnCachedContent(self::$fieldLevelsInVillageSearchCache, $vid.$fieldType)) && !is_null($cachedValue)) {
-            return $cachedValue;
+        // required is already cached. NB: use isset() rather than the generic
+        // returnCachedContent(), which treats a cached level of 0 as "empty" and
+        // re-queries it on every call — buildings the village does not own
+        // (level 0, very common) would otherwise never be cached.
+        if ($use_cache && isset(self::$fieldLevelsInVillageSearchCache[$vid.$fieldType])) {
+            return self::$fieldLevelsInVillageSearchCache[$vid.$fieldType];
         }
 
         // $fieldType can be both, integer and string, to be used in the IN statement,


### PR DESCRIPTION
Phase A (perf) follow-up for #155, surfaced by the per-attack DB measurement.

**Problem**
`getFieldLevelInVillage()` gated its cache read with `returnCachedContent()`, which
treats a cached level of `0` as "empty" and re-runs the query on every call. Since the
query is the heavy 40-field `CASE` scan over `fdata`, and buildings a village does NOT
own (level 0) are extremely common, those lookups were effectively never cached and hit
the DB on every call — e.g. the per-attack battle loop re-queried the same level-0
building on each call.

**Fix**
Use an `isset()` check on the level cache instead, so a level of `0` is cached like any
other value. The cache key and invalidation are unchanged.

**Behaviour-preserving**
The returned value is identical (still `0`); only the query count drops. This matches how
non-zero levels are already cached (same "cleared on write" contract). App-wide benefit,
not just combat.

**Validation**
- A/B combat harness: 8/8 scenarios IDENTICAL (common, evasion, conquest, loot, scout, catapult, ram, reinforce).
- Per-attack query probe: the duplicated level-0 lookup disappears (15 -> 13 real getter queries/attack).
- In-game attack tested OK.