### PR TITLE
i18n: render alliance news-feed notices in each reader's language (EN/FR/RO)

### DIFF
--- a/GameEngine/Alliance.php
+++ b/GameEngine/Alliance.php
@@ -263,11 +263,11 @@ class Alliance {
 			// Log notice în alianță
             $database->insertAlliNotice(
                 $session->alliance,
-                '<a href="spieler.php?uid=' . $session->uid . '">' . 
-                addslashes($session->username) . 
-                '</a> has invited <a href="spieler.php?uid=' . $UserData['id'] . '">' . 
-                addslashes($UserData['username']) . 
-                '</a> into the alliance.'
+                rc_tok(
+                    'MSG_INVITE_NOTICE',
+                    '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>',
+                    '<a href="spieler.php?uid=' . $UserData['id'] . '">' . addslashes($UserData['username']) . '</a>'
+                )
             );
 			// Trimite invitație și prin mesaj în joc (dacă este activată funcționalitatea nouă)
             if (NEW_FUNCTIONS_ALLIANCE_INVITATION) {
@@ -290,8 +290,8 @@ class Alliance {
 				// Ștergem invitația din baza de date
                 $database->removeInvitation($inviteID);
 				// Adăugăm notice în logul alianței
-                $notice = '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a> has rejected the invitation.';
-                $database->insertAlliNotice($invite['alliance'], $notice); 
+                $notice = rc_tok('MSG_NEWS_REJECTED', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>');
+                $database->insertAlliNotice($invite['alliance'], $notice);
                 break; // am găsit și procesat invitația → nu mai continuăm bucla
             }
         }
@@ -318,7 +318,7 @@ class Alliance {
 				// Ștergem invitația
                 $database->removeInvitation($inviteID);
 				// Adăugăm notice în logul alianței
-                $notice = '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a> has deleted the invitation for <a href="spieler.php?uid=' . $invitename['id'] . '">' . addslashes($invitename['username']) . '</a>.';
+                $notice = rc_tok('MSG_NEWS_DELETED_INVITE', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>', '<a href="spieler.php?uid=' . $invitename['id'] . '">' . addslashes($invitename['username']) . '</a>');
                 $database->insertAlliNotice($session->alliance, $notice);
                 break; // am procesat invitația → ieșim din buclă
             }
@@ -349,7 +349,7 @@ class Alliance {
                     $database->updateUserField($invite['uid'], "alliance", $invite['alliance'], 1);
                     $database->createAlliPermissions($invite['uid'], $invite['alliance'], '', 0, 0, 0, 0, 0, 0, 0, 0);
 					// Log notice în alianță
-                    $notice = '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a> has joined the alliance.';
+                    $notice = rc_tok('MSG_NEWS_JOINED', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>');
                     $database->insertAlliNotice($invite['alliance'], $notice);
                 } else {
 					// Alianța este plină
@@ -397,7 +397,7 @@ class Alliance {
         $database->updateUserField($session->uid, "alliance", $aid, 1);
         $database->procAllyPop($aid);
         $database->createAlliPermissions($session->uid, $aid, 'Alliance founder', '1', '1', '1', '1', '1', '1', '1', '1');
-        $notice = 'The alliance has been founded by <a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>.';
+        $notice = rc_tok('MSG_ALLIANCE_FOUNDED', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>');
         $database->insertAlliNotice($aid, $notice);
         header("Location: build.php?gid=18");
         exit;
@@ -421,7 +421,7 @@ class Alliance {
 		// ==================== ERORI ? ====================
         if ($form->returnErrors() == 0) {
             $database->setAlliName($session->alliance, $newName, $newTag);
-            $notice = '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a> has changed the alliance name.';
+            $notice = rc_tok('MSG_NEWS_NAME_CHANGED', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>');
             $database->insertAlliNotice($session->alliance, $notice);
             $form->addError("perm", NAME_OR_TAG_CHANGED);
             $_SESSION['errorarray'] = $form->getErrors();
@@ -447,7 +447,7 @@ class Alliance {
 			// ==================== ACTUALIZARE PROFIL ====================
             $database->submitAlliProfile($session->alliance, $post['be2'] ?? '', $post['be1'] ?? '');
 			// Log notice în alianță
-            $notice = '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a> has changed the alliance description.';
+            $notice = rc_tok('MSG_NEWS_DESC_CHANGED', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>');
             $database->insertAlliNotice($session->alliance, $notice);
         }
     }
@@ -494,7 +494,7 @@ class Alliance {
             } else {
 				// Log notice în alianță
                 $username = $database->getUserField($targetUID, "username", 0);
-                $notice = '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a> has changed permissions of ' . addslashes($username) . '.';
+                $notice = rc_tok('MSG_NEWS_PERMS_CHANGED', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>', addslashes($username));
                 $database->insertAlliNotice($session->alliance, $notice);
 				// Mesaj de succes (comportament original)
                 $_SESSION['success'] = ALLY_PERMISSIONS_UPDATED;
@@ -536,7 +536,7 @@ class Alliance {
         $kickedUsername = $UserData['username'];
         $database->evictUserFromAlliance($targetUID);
         $database->deleteAlliPermissions($targetUID);
-        $notice = '<a href="spieler.php?uid=' . $UserData['id'] . '">' . addslashes($kickedUsername) . '</a> has been expelled from the alliance by <a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>.';
+        $notice = rc_tok('MSG_NEWS_EXPELLED', '<a href="spieler.php?uid=' . $UserData['id'] . '">' . addslashes($kickedUsername) . '</a>', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>');
         $database->insertAlliNotice($allyId, $notice);
         $database->deleteAlliance($allyId);
         $form->addError("perm", $kickedUsername . ALLY_USER_KICKED);
@@ -606,7 +606,7 @@ class Alliance {
         $database->deleteAlliPermissions($uid);
 		// șterge alianța dacă e goală (comportament original)
         $database->deleteAlliance($allyId);
-        $notice = '<a href="spieler.php?uid=' . $uid . '">' . addslashes($session->username) . '</a> has quit the alliance.';
+        $notice = rc_tok('MSG_NEWS_QUIT', '<a href="spieler.php?uid=' . $uid . '">' . addslashes($session->username) . '</a>');
         $database->insertAlliNotice($allyId, $notice);
         header("Location: spieler.php?uid=" . $uid);
         exit;
@@ -630,13 +630,14 @@ class Alliance {
         if (!$database->diplomacyCheckLimits($session->alliance, $diplType)) { $form->addError("name", ALLY_TOO_MUCH_PACTS); return; }
 
         $database->diplomacyInviteAdd($session->alliance, $targetAllianceID, $diplType);
-        if ($diplType == 1) $noticeText = OFFERED_CONFED_TO;
-        elseif ($diplType == 2) $noticeText = OFFERED_NON_AGGRESION_PACT_TO;
-        elseif ($diplType == 3) $noticeText = DECLARED_WAR_ON;
-        else $noticeText = '';
+        if ($diplType == 1) $diploKey = 'MSG_NEWS_DIPLO_CONFED';
+        elseif ($diplType == 2) $diploKey = 'MSG_NEWS_DIPLO_NAP';
+        elseif ($diplType == 3) $diploKey = 'MSG_NEWS_DIPLO_WAR';
+        else $diploKey = '';
         $myAllianceName = $database->getAllianceName($session->alliance);
-        $database->insertAlliNotice($session->alliance, '<a href="allianz.php?aid=' . $session->alliance . '">' . $myAllianceName . '</a> ' . $noticeText . ' <a href="allianz.php?aid=' . $targetAllianceID . '">' . $targetAllianceName . '</a>.');
-        $database->insertAlliNotice($targetAllianceID, '<a href="allianz.php?aid=' . $session->alliance . '">' . $myAllianceName . '</a> ' . $noticeText . ' <a href="allianz.php?aid=' . $targetAllianceID . '">' . $targetAllianceName . '</a>.');
+        $notice = ($diploKey === '') ? '' : rc_tok($diploKey, '<a href="allianz.php?aid=' . $session->alliance . '">' . $myAllianceName . '</a>', '<a href="allianz.php?aid=' . $targetAllianceID . '">' . $targetAllianceName . '</a>');
+        $database->insertAlliNotice($session->alliance, $notice);
+        $database->insertAlliNotice($targetAllianceID, $notice);
         $form->addError("name", INVITE_SENT);
     }
 }

--- a/GameEngine/Lang/en.php
+++ b/GameEngine/Lang/en.php
@@ -283,6 +283,20 @@ tz_def('MSG_QUIT_REPLACEMENT_BODY', "Hi!\n\nThis is to inform you that the forme
 // Embassy-destruction status lines, appended to the catapult battle report.
 tz_def('MSG_ALLIANCE_DISPERSED_STATUS', "This player's alliance has been dispersed.");
 tz_def('MSG_FORCED_LEAVE_STATUS', 'Player was forced to leave their alliance.');
+// Alliance news-feed notices (rendered in Templates/Alliance/news.tpl)
+tz_def('MSG_INVITE_NOTICE', '%s has invited %s into the alliance.');
+tz_def('MSG_ALLIANCE_FOUNDED', 'The alliance has been founded by %s.');
+tz_def('MSG_NEWS_REJECTED', '%s has rejected the invitation.');
+tz_def('MSG_NEWS_DELETED_INVITE', '%s has deleted the invitation for %s.');
+tz_def('MSG_NEWS_JOINED', '%s has joined the alliance.');
+tz_def('MSG_NEWS_NAME_CHANGED', '%s has changed the alliance name.');
+tz_def('MSG_NEWS_DESC_CHANGED', '%s has changed the alliance description.');
+tz_def('MSG_NEWS_PERMS_CHANGED', '%s has changed permissions of %s.');
+tz_def('MSG_NEWS_EXPELLED', '%s has been expelled from the alliance by %s.');
+tz_def('MSG_NEWS_QUIT', '%s has quit the alliance.');
+tz_def('MSG_NEWS_DIPLO_CONFED', '%s offered a confederation to %s.');
+tz_def('MSG_NEWS_DIPLO_NAP', '%s offered non-aggression pact to %s.');
+tz_def('MSG_NEWS_DIPLO_WAR', '%s declared war to %s.');
 tz_def('CARRY', 'carry');
 tz_def('DEFENDER', 'Defender');
 tz_def('VISITED', 'visited');

--- a/GameEngine/Lang/fr.php
+++ b/GameEngine/Lang/fr.php
@@ -280,6 +280,20 @@ define('MSG_QUIT_REPLACEMENT_BODY', "Bonjour !\n\nNous vous informons que l'anci
 // Embassy-destruction status lines, appended to the catapult battle report.
 define('MSG_ALLIANCE_DISPERSED_STATUS', "L'alliance de ce joueur a été dispersée.");
 define('MSG_FORCED_LEAVE_STATUS', "Le joueur a été forcé de quitter son alliance.");
+// Alliance news-feed notices (rendered in Templates/Alliance/news.tpl)
+define('MSG_INVITE_NOTICE', "%s a invité %s à rejoindre l'alliance.");
+define('MSG_ALLIANCE_FOUNDED', "L'alliance a été fondée par %s.");
+define('MSG_NEWS_REJECTED', "%s a refusé l'invitation.");
+define('MSG_NEWS_DELETED_INVITE', "%s a supprimé l'invitation de %s.");
+define('MSG_NEWS_JOINED', "%s a rejoint l'alliance.");
+define('MSG_NEWS_NAME_CHANGED', "%s a changé le nom de l'alliance.");
+define('MSG_NEWS_DESC_CHANGED', "%s a changé la description de l'alliance.");
+define('MSG_NEWS_PERMS_CHANGED', "%s a modifié les permissions de %s.");
+define('MSG_NEWS_EXPELLED', "%s a été expulsé de l'alliance par %s.");
+define('MSG_NEWS_QUIT', "%s a quitté l'alliance.");
+define('MSG_NEWS_DIPLO_CONFED', "%s a proposé une confédération à %s.");
+define('MSG_NEWS_DIPLO_NAP', "%s a proposé un pacte de non-agression à %s.");
+define('MSG_NEWS_DIPLO_WAR', "%s a déclaré la guerre à %s.");
 define('CARRY', 'transporte');
 define('DEFENDER', 'Défenseur');
 define('VISITED', 'visité');

--- a/GameEngine/Lang/ro.php
+++ b/GameEngine/Lang/ro.php
@@ -280,6 +280,20 @@ define('MSG_QUIT_REPLACEMENT_BODY', "Salut!\n\nTe informăm că fostul lider al 
 // Embassy-destruction status lines, appended to the catapult battle report.
 define('MSG_ALLIANCE_DISPERSED_STATUS', 'Alianța acestui jucător a fost dispersată.');
 define('MSG_FORCED_LEAVE_STATUS', 'Jucătorul a fost forțat să-și părăsească alianța.');
+// Alliance news-feed notices (rendered in Templates/Alliance/news.tpl)
+define('MSG_INVITE_NOTICE', '%s l-a invitat pe %s în alianță.');
+define('MSG_ALLIANCE_FOUNDED', 'Alianța a fost fondată de %s.');
+define('MSG_NEWS_REJECTED', '%s a refuzat invitația.');
+define('MSG_NEWS_DELETED_INVITE', '%s a șters invitația pentru %s.');
+define('MSG_NEWS_JOINED', '%s s-a alăturat alianței.');
+define('MSG_NEWS_NAME_CHANGED', '%s a schimbat numele alianței.');
+define('MSG_NEWS_DESC_CHANGED', '%s a schimbat descrierea alianței.');
+define('MSG_NEWS_PERMS_CHANGED', '%s a modificat permisiunile lui %s.');
+define('MSG_NEWS_EXPELLED', '%s a fost exclus din alianță de către %s.');
+define('MSG_NEWS_QUIT', '%s a părăsit alianța.');
+define('MSG_NEWS_DIPLO_CONFED', '%s a oferit o confederație către %s.');
+define('MSG_NEWS_DIPLO_NAP', '%s a oferit un pact de neagresiune către %s.');
+define('MSG_NEWS_DIPLO_WAR', '%s a declarat război către %s.');
 define('CARRY', 'transportă');
 define('DEFENDER', 'Apărător');
 define('VISITED', 'vizitat');

--- a/Templates/Alliance/news.tpl
+++ b/Templates/Alliance/news.tpl
@@ -64,7 +64,7 @@ if (!empty($noticeArray)) {
 
         echo "<tr>
 
-            <td class=\"event\">" . html_entity_decode($notice['comment'], ENT_QUOTES, 'UTF-8') . "</td>
+            <td class=\"event\">" . html_entity_decode(tz_expand_report($notice['comment']), ENT_QUOTES, 'UTF-8') . "</td>
 
             <td class=\"dat\">" .
                 $date[0] . " " . $date[1] .


### PR DESCRIPTION
Follow-up to #236 (battle reports) and #237 (system in-game messages). The
alliance news feed (insertAlliNotice -> Templates/Alliance/news.tpl) was the
last display surface still baking strings at write time: most notices were
hardcoded in English, and the invitation/founding ones were frozen in the
writer's language.

Emit language-neutral tokens via rc_tok() and expand them in the reader's
language with tz_expand_report(), wired into news.tpl (same token layer used for
battle reports and system messages). Covers all 11 notices: invitation,
founding, rejected/deleted invite, joined, name/description/permissions change,
expel, quit and the three diplomacy variants (confederation / non-aggression /
war). New MSG_INVITE_NOTICE, MSG_ALLIANCE_FOUNDED and MSG_NEWS_* strings in
en.php (fallback), fr.php and ro.php; the diplomacy variants reuse the existing
wording.

Tested in-game (FR and EN accounts each read these notices in their own
language).