### PR TITLE
fix(session): refresh the 30s user-cache after a player's own changes

### DIFF
--- a/GameEngine/Alliance.php
+++ b/GameEngine/Alliance.php
@@ -348,6 +348,10 @@ class Alliance {
                     $database->removeInvitation($inviteID);
                     $database->updateUserField($invite['uid'], "alliance", $invite['alliance'], 1);
                     $database->createAlliPermissions($invite['uid'], $invite['alliance'], '', 0, 0, 0, 0, 0, 0, 0, 0);
+                    // Invalidate the 30s session user-cache (see Session::PopulateVar) so the
+                    // new alliance membership shows up immediately, without a re-login.
+                    unset($_SESSION['cache_user_' . $session->username]);
+                    $_SESSION['alliance_user'] = $invite['alliance'];
 					// Log notice în alianță
                     $notice = rc_tok('MSG_NEWS_JOINED', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>');
                     $database->insertAlliNotice($invite['alliance'], $notice);
@@ -397,6 +401,10 @@ class Alliance {
         $database->updateUserField($session->uid, "alliance", $aid, 1);
         $database->procAllyPop($aid);
         $database->createAlliPermissions($session->uid, $aid, 'Alliance founder', '1', '1', '1', '1', '1', '1', '1', '1');
+        // Invalidate the 30s session user-cache (see Session::PopulateVar) so the
+        // new alliance shows up immediately, without a re-login.
+        unset($_SESSION['cache_user_' . $session->username]);
+        $_SESSION['alliance_user'] = $aid;
         $notice = rc_tok('MSG_ALLIANCE_FOUNDED', '<a href="spieler.php?uid=' . $session->uid . '">' . addslashes($session->username) . '</a>');
         $database->insertAlliNotice($aid, $notice);
         header("Location: build.php?gid=18");
@@ -606,6 +614,10 @@ class Alliance {
         $database->deleteAlliPermissions($uid);
 		// șterge alianța dacă e goală (comportament original)
         $database->deleteAlliance($allyId);
+        // Invalidate the 30s session user-cache (see Session::PopulateVar) so the
+        // alliance the player just left disappears immediately, without a re-login.
+        unset($_SESSION['cache_user_' . $session->username]);
+        $_SESSION['alliance_user'] = 0;
         $notice = rc_tok('MSG_NEWS_QUIT', '<a href="spieler.php?uid=' . $uid . '">' . addslashes($session->username) . '</a>');
         $database->insertAlliNotice($allyId, $notice);
         header("Location: spieler.php?uid=" . $uid);

--- a/GameEngine/Building.php
+++ b/GameEngine/Building.php
@@ -1760,6 +1760,10 @@ class Building {
 
         $session->gold = $newgold;
         $_SESSION['gold'] = $newgold;
+        // Invalidate the 30s session user-cache (see Session::PopulateVar); the gold
+        // write is absolute ($session->gold - $spent), so a stale cache would revert
+        // the balance next request and could allow a double-spend.
+        unset($_SESSION['cache_user_' . ($_SESSION['username'] ?? '')]);
     }
 
     // un singur query

--- a/GameEngine/Lang/en.php
+++ b/GameEngine/Lang/en.php
@@ -1384,6 +1384,7 @@ tz_def('OLD_PASSWORD', 'Old password');
 tz_def('NEW_PASSWORD', 'New password');
 tz_def('CHANGE_EMAIL', 'Change email');
 tz_def('CHANGE_EMAIL2', 'Please enter your old and your new e-mail addresses. You will then receive a code snippet at both e-mail addresses which you have to enter here');
+tz_def('CURRENT_EMAIL', 'Current email');
 tz_def('OLD_EMAIL', 'Old email');
 tz_def('NEW_EMAIL', 'New email');
 tz_def('ACCOUNT_SITTERS', 'Account sitters');

--- a/GameEngine/Lang/fr.php
+++ b/GameEngine/Lang/fr.php
@@ -1703,6 +1703,7 @@ define('OLD_PASSWORD', 'Ancien mot de passe');
 define('NEW_PASSWORD', 'Nouveau mot de passe');
 define('CHANGE_EMAIL', 'Changer d\'e-mail');
 define('CHANGE_EMAIL2', 'Veuillez saisir vos anciennes et nouvelles adresses e-mail. Vous recevrez ensuite un code à saisir ici aux deux adresses.');
+define('CURRENT_EMAIL', 'E-mail actuel');
 define('OLD_EMAIL', 'Ancien e-mail');
 define('NEW_EMAIL', 'Nouvel e-mail');
 define('ACCOUNT_SITTERS', 'Substituts du compte');

--- a/GameEngine/Lang/ro.php
+++ b/GameEngine/Lang/ro.php
@@ -1379,6 +1379,7 @@ define('OLD_PASSWORD', 'Parolă veche');
 define('NEW_PASSWORD', 'Parolă nouă');
 define('CHANGE_EMAIL', 'Schimbă email');
 define('CHANGE_EMAIL2', 'Introdu adresa veche și cea nouă de email. Vei primi un cod pe ambele adrese pe care trebuie să-l introduci aici');
+define('CURRENT_EMAIL', 'Email actual');
 define('OLD_EMAIL', 'Email vechi');
 define('NEW_EMAIL', 'Email nou');
 define('ACCOUNT_SITTERS', 'Sitteri cont');

--- a/GameEngine/Profile.php
+++ b/GameEngine/Profile.php
@@ -238,6 +238,10 @@ class Profile {
 			$database->RemoveXSS($post['custom_url'])
 		);
 
+		// Invalidate the 30s session user-cache (see Session::PopulateVar) so the
+		// new graphics pack applies immediately, without a re-login.
+		unset($_SESSION['cache_user_' . ($_SESSION['username'] ?? '')]);
+
 		header("Location: spieler.php?uid=" . $session->uid);
 		exit;
 	}
@@ -377,6 +381,11 @@ class Profile {
 			$_SESSION['valuearray'] = $_POST;
 		}
 
+		// Invalidate the 30s session user-cache (see Session::PopulateVar) so the
+		// updated account fields (email, sitters, password) are reflected
+		// immediately, without a re-login.
+		unset($_SESSION['cache_user_' . ($_SESSION['username'] ?? '')]);
+
 		header("Location: spieler.php?s=3");
 		exit;
 	}
@@ -391,6 +400,9 @@ class Profile {
 
 			if ($session->userinfo['sit' . $get['type']] == $get['id']) {
 				$database->updateUserField($session->uid, "sit" . $get['type'], 0, 1);
+				// Invalidate the 30s session user-cache (see Session::PopulateVar) so the
+				// removed sitter disappears immediately, without a re-login.
+				unset($_SESSION['cache_user_' . ($_SESSION['username'] ?? '')]);
 			}
 
 			$session->changeChecker();

--- a/Templates/Profile/account.tpl
+++ b/Templates/Profile/account.tpl
@@ -88,6 +88,11 @@ if (!empty($pwError)) {
 </tr>
 
 <tr>
+    <th><?php echo CURRENT_EMAIL; ?></th>
+    <td><?php echo htmlspecialchars($session->userinfo['email'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+</tr>
+
+<tr>
     <th><?php echo OLD_EMAIL; ?></th>
     <td><input class="text" type="text" name="email_alt" /></td>
 </tr>

--- a/build.php
+++ b/build.php
@@ -110,6 +110,11 @@ if ($session->goldclub == 1 && count($session->villages) > 1) {
                 $database->editTradeRoute($_POST['routeid'], "timeleft", 604800, 1);
                 $newgold = $session->gold - 2;
                 $database->updateUserField($session->uid, 'gold', $newgold, 1);
+                $session->gold = $newgold;
+                // Invalidate the 30s session user-cache (see Session::PopulateVar) so
+                // the gold balance is fresh next request; the write is absolute
+                // ($session->gold - 2), so a stale cache could double-spend.
+                unset($_SESSION['cache_user_' . ($_SESSION['username'] ?? '')]);
             }
         }
         $route = 1;

--- a/dorf1.php
+++ b/dorf1.php
@@ -22,6 +22,10 @@ AccessLogger::logRequest();
 if(isset($_GET['ok'])){
 	$database->updateUserField($session->uid,'ok', 0, 1);
 	$_SESSION['ok'] = '0';
+	// Invalidate the 30s session user-cache (see Session::PopulateVar); otherwise
+	// it re-seeds $_SESSION['ok'] from the stale row and the welcome/maintenance
+	// redirect keeps firing for up to 30s after acknowledging.
+	unset($_SESSION['cache_user_' . ($_SESSION['username'] ?? '')]);
 }
 
 if(isset($_GET['newdid'])) {


### PR DESCRIPTION
The session keeps a 30s cache of the logged-in player's user row
(Session::PopulateVar). When a player mutated one of their own cached fields,
the cache was not invalidated, so the change only showed after the TTL expired
or a re-login. Audited and fixed all the affected self-mutation sites, mirroring
the pattern already used in Profile::updatePreferences().

Fixes:
- Alliance: accept invitation / found / quit an alliance (membership now shows
  immediately, no re-login).
- Profile: graphics-pack (skin) change, account changes (email / sitter /
  password), sitter removal.
- dorf1.php (?ok): the welcome/maintenance acknowledge flag was re-seeded from
  the stale row, so the maintenance redirect kept firing for up to 30s.
- Gold: build.php (trade-route extend) and Building.php (finish-all) write an
  absolute value ($session->gold - n); a stale cache reverted the balance next
  request and could allow a double-spend.

Also included (small UX): the change-email form now shows a read-only "Current
email" row, so the player can see the address on file (new CURRENT_EMAIL string
in en/fr/ro).

Tested in-game.