### PR TITLE
fix(admin): re-check admin rank in addUsers Mod (defense-in-depth) [#139]

### DIFF
--- a/GameEngine/Admin/Mods/addUsers.php
+++ b/GameEngine/Admin/Mods/addUsers.php
@@ -26,6 +26,16 @@ include_once($autoprefix."GameEngine/Session.php");
 include_once($autoprefix."GameEngine/Automation.php");
 include_once($autoprefix."GameEngine/Database.php");
 
+// Admin-rank guard (defense-in-depth). Reaching any file under /Admin already
+// requires an admin session: Session.php's checkLogin() gates the whole /Admin
+// path on $_SESSION['admin_username'], so a plain player session is bounced to
+// login.php before this point. This re-check aligns addUsers with its sibling
+// Mods (gold.php, cp.php, editResources.php, ...), which all assert the rank
+// here too; it is a redundant safety net, not the sole guard.
+if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
+    die("Access Denied: You are not Admin!");
+}
+
 $wgarray = array(1=>1200,1700,2300,3100,4000,5000,6300,7800,9600,11800,14400,17600,21400,25900,31300,37900,45700,55100,66400,80000);
 
 foreach ($_POST as $key => $value) {


### PR DESCRIPTION
## Summary

`addUsers.php` can be accessed directly via POST and, unlike its sibling Admin Mods (`gold.php`, `cp.php`, `editResources.php`, etc.), did not explicitly re-check the administrator access level.

However, reaching any file under `/Admin` already requires a valid administrator session. `Session.php` derives the administrative context from the request URI and protects the entire `/Admin` path through `$_SESSION['admin_username']`. Requests from a regular player session are redirected to `login.php` before the Mod code is executed.

As a result, this change does **not** fix an exploitable authorization bypass. It adds a redundant authorization check as a defense-in-depth measure and aligns `addUsers.php` with the authorization pattern already used by the other Admin Mods.

## Changes

* Added an explicit `$_SESSION['access'] < 9` check to `addUsers.php`.
* Matched the authorization logic used by other Admin Mods.
* Improved consistency and resilience against future regressions.

## Security Impact

* No known exploitable vulnerability is fixed by this PR.
* The existing `/Admin` session guard remains the primary protection layer.
* This change provides an additional authorization check and improves code consistency.
