### PR TITLE
fix(chat): replace eval() of server output with JSON.parse() [#139]

### DIFF
--- a/GameEngine/Chat.php
+++ b/GameEngine/Chat.php
@@ -110,7 +110,9 @@ if (!isset($SAJAX_INCLUDED)) {
 		else {
 			echo "+:";
 			$result = call_user_func_array($func_name, $args);
-			echo "var res = " . trim(sajax_get_js_repr($result)) . "; res;";
+			// Emit the result as JSON so the client can JSON.parse() it instead
+			// of eval()-ing server output (DOM-XSS / arbitrary code execution).
+			echo json_encode($result);
 		}
 		exit;
 	}
@@ -250,7 +252,7 @@ if (!isset($SAJAX_INCLUDED)) {
 						alert("Error: " + data);
 					else {
 						if (target_id != "")
-							document.getElementById(target_id).innerHTML = eval(data);
+							document.getElementById(target_id).innerHTML = JSON.parse(data);
 						else {
 							try {
 								var callback;
@@ -261,7 +263,7 @@ if (!isset($SAJAX_INCLUDED)) {
 								} else {
 									callback = args[args.length-1];
 								}
-								callback(eval(data), extra_data);
+								callback(JSON.parse(data), extra_data);
 							} catch (e) {
 								sajax_debug("Caught error " + e + ": Could not eval " + data );
 							}


### PR DESCRIPTION
`GameEngine/Chat.php` uses the legacy sajax layer: the server emitted `var res = <repr>; res;` and the client ran `eval(data)` on the raw server response in two places — the `innerHTML` render and the callback path. Running `eval()` on server output is a DOM-XSS / arbitrary-code-execution vector.

**Fix:** emit the result with `json_encode()` server-side and read it with `JSON.parse()` client-side instead:

```php
// server (sajax_handle_client_request)
echo json_encode($result);
```
```js
// client
document.getElementById(target_id).innerHTML = JSON.parse(data);
// ...
callback(JSON.parse(data), extra_data);
```

For the HTML-string payload the chat returns, `json_encode` → `JSON.parse` yields the exact same value, so this is behaviour-preserving while never evaluating server output as code.

Part of the #139 admin hardening series.

**Tested in-game:** alliance chat — sending messages, auto-refresh, and messages with special characters (accents, `<`, `>`, `"`, `'`) all render correctly.