### PR TITLE
fix(chat): stop echoing the raw INSERT query in add_data() [#139]

### DIFF
--- a/GameEngine/Chat.php
+++ b/GameEngine/Chat.php
@@ -366,7 +366,7 @@ if (!isset($SAJAX_INCLUDED)) {
 		    $id_user = (int) $session->uid;
 			$alliance = $database->escape($session->alliance);
 			$now = time();
-				echo $q = "INSERT into ".TB_PREFIX."chat (id_user,name,alli,date,msg) values ($id_user,'$name','$alliance','$now','$msg')";
+				$q = "INSERT into ".TB_PREFIX."chat (id_user,name,alli,date,msg) values ($id_user,'$name','$alliance','$now','$msg')";
 				mysqli_query($database->dblink,$q);
 		}
 	}


### PR DESCRIPTION
`add_data()` in `GameEngine/Chat.php` ran:

```php
echo $q = "INSERT into ".TB_PREFIX."chat (id_user,name,alli,date,msg) values (...)";
mysqli_query($database->dblink,$q);
```

The `echo` leaked the raw SQL statement (table name + values) into the HTTP response on every chat message — an information disclosure, and a leftover debug artifact. It also corrupts the sajax response stream now that the client `JSON.parse()`s the reply instead of `eval()`-ing it.

**Fix:** drop the `echo`, keep the assignment for `mysqli_query()`.

Part of the #139 admin hardening series.

**Tested in-game:** sending a chat message now returns `+:null` (no SQL in the response), and messages still send/render normally.