### PR TITLE
fix(reports): pass aid on vilview report links so ally reports open [#246]

### DIFF
--- a/Templates/Map/vilview.tpl
+++ b/Templates/Map/vilview.tpl
@@ -68,7 +68,13 @@ function renderReports($database,$generator,$session,$d,$limit,$typeMap=null){
             $icon = '<img src="img/x.gif" class="iReport iReport'.$row['ntype'].'" title="'.$row['topic'].'">';
         }
         $date = $generator->procMtime($row['time']);
-        echo '<tr><td>'.$icon.' <a href="berichte.php?id='.$row['id'].'">'.$date[0].' '.substr($date[1],0,5).'</a></td></tr>';
+        // Reports here are selected by `ally = session alliance` (shared alliance
+        // reports) whenever the viewer is in an alliance, so they may be owned by
+        // an ally rather than the viewer. berichte.php only renders such a report
+        // when the `aid` param is present (its uid-owner branch fails for allies),
+        // hence the blank page. Append &aid= like Alliance/attacks.tpl does.
+        $link = 'berichte.php?id='.$row['id'].($session->alliance? '&amp;aid='.(int)$session->alliance : '');
+        echo '<tr><td>'.$icon.' <a href="'.$link.'">'.$date[0].' '.substr($date[1],0,5).'</a></td></tr>';
     }
 }
 ?>


### PR DESCRIPTION
## Problem

Clicking a report from a village view (`Map/vilview.tpl` → "Report" list) opens `berichte.php` with an **empty content area** (blank page) when the report belongs to a *fellow alliance member* rather than the viewer. Reproduced from the issue video: viewing another player's village (via profile → village), the report link leads to `berichte.php?id=XXXX` and renders nothing.

## Cause

`renderReports()` in `Templates/Map/vilview.tpl` lists reports filtered by `ally = <viewer alliance>` (shared alliance reports) whenever the viewer belongs to an alliance, so the list can include reports owned by an ally, not the viewer. The generated link was `berichte.php?id=XXXX` with **no `aid` param**.

`berichte.php` only renders an alliance-shared report through its `aid` branch:
```php
if (isset($_GET['aid']) && $_GET['aid'] > 0 && $_GET['aid'] == $session->alliance && $database->getNotice2($_GET['id'], 'ally') == $session->alliance) { ... }
```
Without `aid`, the only remaining match is the uid-owner branch, which fails for an ally's report → `$type` is never set → no template is included → blank page.

## Fix

Append `&aid=<alliance>` to the vilview report link when the viewer is in an alliance, mirroring what `Templates/Alliance/attacks.tpl` already does (`berichte.php?id=$id&aid=$ally`). The `aid` branch then matches every listed report (the list is already filtered by `ally = <viewer alliance>`), including the viewer's own.

## Testing

- In-game: opening a fellow-alliance-member report from a village view now renders correctly (previously blank). URL now carries `&aid=`.
- Non-regression: own reports from your own village's view still open; the Alliance → Attacks links (already carrying `aid`) are unchanged.