### PR TITLE
fix(admin): verify CSRF token in Plus/Gold admin Mods [#139]

### DIFF
--- a/Admin/Templates/editPlus.tpl
+++ b/Admin/Templates/editPlus.tpl
@@ -66,6 +66,7 @@ if($id){
     </div>
 
     <form action="../GameEngine/Admin/Mods/editPlus.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="admid" value="<?php echo $_SESSION['id'];?>">
         <input type="hidden" name="uid" value="<?php echo $uid;?>">
         <input type="hidden" name="id" value="<?php echo $id;?>">

--- a/Admin/Templates/givePlus.tpl
+++ b/Admin/Templates/givePlus.tpl
@@ -55,6 +55,7 @@ $id = $_SESSION['id'];
     <p>Activate Travian Plus for ALL players on the server.</p>
 
     <form action="../GameEngine/Admin/Mods/givePlus.php" method="POST" class="plus-form">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="admid" value="<?php echo $id; ?>">
       <input type="number" name="plus" value="1" min="1" max="365" required>
       <span>Days</span>

--- a/Admin/Templates/givePlusRes.tpl
+++ b/Admin/Templates/givePlusRes.tpl
@@ -62,6 +62,7 @@ $id = $_SESSION['id'];
     </div>
 
     <form action="../GameEngine/Admin/Mods/givePlusRes.php" method="POST" class="resbonus-form">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="admid" value="<?php echo $id; ?>">
       
       <div class="res-grid">

--- a/Admin/Templates/gold.tpl
+++ b/Admin/Templates/gold.tpl
@@ -52,6 +52,7 @@ $id = $_SESSION['id'];
     <p>This gold will be added to ALL active players on the server.</p>
 
     <form action="../GameEngine/Admin/Mods/gold.php" method="POST" class="gold-form">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="admid" value="<?php echo $id; ?>">
       <input type="number" name="gold" value="20" min="1" max="9999" required>
       <button type="submit">

--- a/Admin/Templates/usergold.tpl
+++ b/Admin/Templates/usergold.tpl
@@ -60,6 +60,7 @@ $id = $_SESSION['id'];
     </div>
 
     <form action="../GameEngine/Admin/Mods/gold_1.php" method="POST" class="usergold-form">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="admid" value="<?php echo $id; ?>">
       
       <div class="field">

--- a/GameEngine/Admin/Mods/editPlus.php
+++ b/GameEngine/Admin/Mods/editPlus.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/givePlus.php
+++ b/GameEngine/Admin/Mods/givePlus.php
@@ -18,6 +18,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/givePlusRes.php
+++ b/GameEngine/Admin/Mods/givePlusRes.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/gold.php
+++ b/GameEngine/Admin/Mods/gold.php
@@ -12,6 +12,12 @@
 #################################################################################
 if (!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 error_reporting(E_ALL);

--- a/GameEngine/Admin/Mods/gold_1.php
+++ b/GameEngine/Admin/Mods/gold_1.php
@@ -15,6 +15,11 @@
 if (!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 include_once("../../Database.php");
 


### PR DESCRIPTION
Part of #139 (admin CSRF hardening).

The CSRF foundation (#244) wired `csrf_field()` into the forms that POST
**through `admin.php`**, which verifies the token centrally. But the admin Mods
under `GameEngine/Admin/Mods/` are POSTed to **directly**, so they never reach
that central `csrf_verify()` and remained unprotected.

This lot covers the **Plus & Gold** group:

| Mod (direct POST target) | Form template |
|---|---|
| `gold.php` | `gold.tpl` |
| `gold_1.php` | `usergold.tpl` |
| `givePlus.php` | `givePlus.tpl` |
| `givePlusRes.php` | `givePlusRes.tpl` |
| `editPlus.php` | `editPlus.tpl` |

Each Mod now includes the shared `GameEngine/Admin/csrf.php` and calls
`csrf_verify()` right after its admin access check (before any DB write); the
matching form emits `csrf_field()`. `csrf.php` is re-includable (guarded with
`function_exists` + defensive `session_start`).

Tested in-game: all five admin actions work normally with the token present.
Remaining Mod groups (players, alliance/medals, messages, maintenance, server
settings) will follow in separate isolated PRs.