### PR TITLE
fix(admin): let editPlus subtract Plus/bonus days as the form advertises

### DIFF
--- a/Admin/Templates/editPlus.tpl
+++ b/Admin/Templates/editPlus.tpl
@@ -70,7 +70,7 @@ if($id){
         <input type="hidden" name="uid" value="<?php echo $uid;?>">
         <input type="hidden" name="id" value="<?php echo $id;?>">
 
-        <div class="info-box">ℹ️ The values ​​add up. Put 5 to add 5 days.</div>
+        <div class="info-box">ℹ️ The values ​​add up. Put 5 to add 5 days, -5 to remove 5 days.</div>
 
         <div class="card">
             <h3>📊 Current Active Bonuses</h3>

--- a/GameEngine/Admin/Mods/editPlus.php
+++ b/GameEngine/Admin/Mods/editPlus.php
@@ -59,7 +59,9 @@ if (!$user) {
 foreach ($bonusDuration as $key => $add) {
     $current = (int)($user[$key] ?? 0);
     $base = $current < $time ? $time : $current;
-    $bonusDuration[$key] = $add > 0 ? $base + $add : $current;
+    // A negative value subtracts days (the form advertises "Add / Remove Days").
+    // 0 leaves the current expiry untouched; the clamp below caps it at "expired".
+    $bonusDuration[$key] = $add != 0 ? $base + $add : $current;
     if ($bonusDuration[$key] < $time) {
         $bonusDuration[$key] = 0;
     }


### PR DESCRIPTION
The "Edit Plus" admin screen (fiche player → Edit Plus) titles its inputs
**"Add / Remove Days"**, but the backend only ever added time:

```php
$bonusDuration[$key] = $add > 0 ? $base + $add : $current;
```

Any value `<= 0` was silently dropped, so entering `-5` did nothing — only
addition worked.

Fix: use `$add != 0` so a negative value reduces the bonus expiry. The existing
clamp right below caps the result at "expired" (`0`), so over-subtracting just
expires the bonus instead of producing a negative timestamp. The info-box text
now mentions removal (`-5 to remove 5 days`).

Tested in-game: `-2` removes 2 days, `+3` still adds, and over-subtracting
expires the bonus cleanly.