### PR TITLE
fix(admin): verify CSRF token in player-management admin Mods [#139]

### DIFF
--- a/Admin/Templates/addUsers.tpl
+++ b/Admin/Templates/addUsers.tpl
@@ -103,6 +103,7 @@ elseif(isset($_GET['g']) && $_GET['g']=='OK'){
     </div>
 
     <form action="../GameEngine/Admin/Mods/addUsers.php" method="POST" class="add-form">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="id" value="<?php echo $id;?>">
 
       <?php if($errorMsg){?><div class="alert alert-err">✗ <?php echo $errorMsg;?></div><?php }?>

--- a/Admin/Templates/editAccess.tpl
+++ b/Admin/Templates/editAccess.tpl
@@ -28,6 +28,7 @@ if(isset($_GET['uid']))
 	?>
 
 	<form action="../GameEngine/Admin/Mods/editAccess.php" method="POST">
+		<?php echo csrf_field(); ?>
 		<input type="hidden" name="admid" id="admid" value="<?php echo $_SESSION['id']; ?>">
 		<input type="hidden" name="uid" id="uid" value="<?php echo $_GET['uid']; ?>">
 		<table id="member" style="width:300px;">

--- a/Admin/Templates/editAdditional.tpl
+++ b/Admin/Templates/editAdditional.tpl
@@ -72,6 +72,7 @@ if(isset($id)) {
     </div>
 
     <form action="../GameEngine/Admin/Mods/additional.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
         <input type="hidden" name="id" value="<?php echo $id; ?>" />
 

--- a/Admin/Templates/editHero.tpl
+++ b/Admin/Templates/editHero.tpl
@@ -132,6 +132,7 @@ function go_url(url){ location=url; return false; }
     </div>
 
 <form name="frmHero" action="../GameEngine/Admin/Mods/editHero.php" method="POST">
+    <?php echo csrf_field(); ?>
     <input type="hidden" name="admid" value="<?php echo $_SESSION['id'];?>">
     <input type="hidden" name="id" value="<?php echo $id;?>" />
     <input type="hidden" name="hid" value="<?php echo $hid;?>" />

--- a/Admin/Templates/editPassword.tpl
+++ b/Admin/Templates/editPassword.tpl
@@ -75,6 +75,7 @@ function genPw(){
     </div>
 
     <form action="../GameEngine/Admin/Mods/editPassword.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
         <input type="hidden" name="uid" value="<?php echo $uid; ?>">
 

--- a/Admin/Templates/editProtection.tpl
+++ b/Admin/Templates/editProtection.tpl
@@ -74,6 +74,7 @@ function setDays(d){ document.getElementById('protect').value = d; }
     </div>
 
     <form action="../GameEngine/Admin/Mods/editProtection.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
         <input type="hidden" name="uid" value="<?php echo $uid; ?>">
         <input type="hidden" name="id" value="<?php echo $id; ?>">

--- a/Admin/Templates/editSitter.tpl
+++ b/Admin/Templates/editSitter.tpl
@@ -69,6 +69,7 @@ function clearSitter(n){ document.getElementById('sit'+n).value = '0'; }
     </div>
 
     <form action="../GameEngine/Admin/Mods/editSitter.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
         <input type="hidden" name="uid" value="<?php echo $uid; ?>">
         <input type="hidden" name="id" value="<?php echo $id; ?>">

--- a/Admin/Templates/editUser.tpl
+++ b/Admin/Templates/editUser.tpl
@@ -84,6 +84,7 @@ select.dropdown { width:100%; }
                 <!-- USERNAME EDIT - NOU -->
                 <div class="username-row">
                     <form action="../GameEngine/Admin/Mods/editUsername.php" method="POST">
+                        <?php echo csrf_field(); ?>
                         <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
                         <input type="hidden" name="uid" value="<?php echo $uid; ?>">
                         <div class="form-row">
@@ -96,6 +97,7 @@ select.dropdown { width:100%; }
 
                 <!-- RESTUL FORMULUI PRINCIPAL -->
                 <form action="../GameEngine/Admin/Mods/editUser.php" method="POST">
+                    <?php echo csrf_field(); ?>
                     <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
                     <input type="hidden" name="uid" value="<?php echo $uid; ?>" />
                     <input type="hidden" name="id" value="<?php echo $id; ?>" />

--- a/GameEngine/Admin/Mods/addUsers.php
+++ b/GameEngine/Admin/Mods/addUsers.php
@@ -36,6 +36,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 $wgarray = array(1=>1200,1700,2300,3100,4000,5000,6300,7800,9600,11800,14400,17600,21400,25900,31300,37900,45700,55100,66400,80000);
 
 foreach ($_POST as $key => $value) {

--- a/GameEngine/Admin/Mods/additional.php
+++ b/GameEngine/Admin/Mods/additional.php
@@ -21,6 +21,11 @@ include_once("../../Database.php");
 if (!isset($_SESSION)) session_start();
 if(($_SESSION['access']?? 0) < ADMIN) die("Access Denied: You are not Admin!");
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 // --- INPUT ---
 $id = (int)($_POST['id']?? 0);
 $admid = (int)($_POST['admid']?? 0);

--- a/GameEngine/Admin/Mods/editAccess.php
+++ b/GameEngine/Admin/Mods/editAccess.php
@@ -10,6 +10,12 @@
 #################################################################################
 if (!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // go max 5 levels up - we don't have folders that go deeper than that

--- a/GameEngine/Admin/Mods/editHero.php
+++ b/GameEngine/Admin/Mods/editHero.php
@@ -18,6 +18,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 // ---------------------------------------------------------------------------
 // Autoloader path
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editPassword.php
+++ b/GameEngine/Admin/Mods/editPassword.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editProtection.php
+++ b/GameEngine/Admin/Mods/editProtection.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editSitter.php
+++ b/GameEngine/Admin/Mods/editSitter.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editUser.php
+++ b/GameEngine/Admin/Mods/editUser.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editUsername.php
+++ b/GameEngine/Admin/Mods/editUsername.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #139, follow-up to #244/#253. The player-management admin Mods are
POSTed to directly, bypassing admin.php's central csrf_verify(). Adds
csrf_verify() (after the admin access check, via the shared
GameEngine/Admin/csrf.php) and csrf_field() in the matching forms for:
editUser, editUsername, editAccess, editPassword, editSitter, additional,
editProtection, editHero, addUsers. Tested in-game (all 9 work with the token).

> Heads-up @Shadowss: this PR and `Ferywir:fix/admin-panel-fixes` both touch
> `GameEngine/Admin/Mods/editUsername.php`, but in different regions — this one
> adds the CSRF guard at the top of the file, the other changes the username
> validation block mid-file. They're independent; whichever you merge first, the
> other may need a trivial rebase (no logical conflict).