### PR TITLE
fix(admin): route password/protection pages and align username validation

### DIFF
--- a/Admin/admin.php
+++ b/Admin/admin.php
@@ -86,7 +86,8 @@ function admin_validated_page(string $raw): string
         'addUsers', 'users', 'admin_log', 'config', 'debug_log',
         'editServerSet', 'editPlusSet', 'editLogSet', 'editNewsboxSet',
         'editExtraSet', 'editAdminInfo', 'resetServer', 'player', 'editUser',
-        'deletion', 'Newmessage', 'editPlus', 'editSitter', 'editOverall',
+        'deletion', 'Newmessage', 'editPlus', 'editSitter', 'editPassword',
+        'editProtection', 'editOverall',
         'editWeek', 'userlogin', 'userillegallog', 'editHero', 'editAdditional',
         'village', 'editResources', 'addTroops', 'addABTroops', 'editVillage',
         'villagelog', 'techlog', 'msg',
@@ -344,6 +345,26 @@ if ($page !== '') {
                 $subpage = 'Edit Sitters (' . e($user['username']) . ')';
             } else {
                 $subpage = 'Edit Sitters';
+            }
+            break;
+
+        case 'editPassword':
+            $uid = admin_input_id($_GET, 'uid');
+            if ($uid !== null) {
+                $user    = $database->getUserArray($uid, 1);
+                $subpage = 'Edit Password (' . e($user['username']) . ')';
+            } else {
+                $subpage = 'Edit Password';
+            }
+            break;
+
+        case 'editProtection':
+            $uid = admin_input_id($_GET, 'uid');
+            if ($uid !== null) {
+                $user    = $database->getUserArray($uid, 1);
+                $subpage = 'Edit Protection (' . e($user['username']) . ')';
+            } else {
+                $subpage = 'Edit Protection';
             }
             break;
 

--- a/GameEngine/Admin/Mods/editUsername.php
+++ b/GameEngine/Admin/Mods/editUsername.php
@@ -55,7 +55,18 @@ if (!$admin || (int)$admin['access'] !== 9) {
 // ---------------------------------------------------------------------------
 // Validare username
 // ---------------------------------------------------------------------------
-if (strlen($username) < 3 || strlen($username) > 20 || !preg_match('/^[a-zA-Z0-9_]+$/', $username)) {
+// Mirror the sign-up rule (Account.php, issue #184) so an admin can rename a
+// player to any name registration would accept. The allowed character set
+// depends on USRNM_SPECIAL: when on, letters/digits/.-_ and single internal
+// spaces; when off, ASCII alphanumerics only.
+$usernameSpecial = defined('USRNM_SPECIAL') ? USRNM_SPECIAL : false;
+$minLen = defined('USRNM_MIN_LENGTH') ? USRNM_MIN_LENGTH : 3;
+$maxLen = defined('USRNM_MAX_LENGTH') ? USRNM_MAX_LENGTH : 15;
+$charsOk = $usernameSpecial
+    ? (bool)preg_match('/^[A-Za-z0-9._-]+(?: [A-Za-z0-9._-]+)*$/D', $username)
+    : !preg_match('/[^0-9A-Za-z]/', $username);
+
+if (strlen($username) < $minLen || strlen($username) > $maxLen || !$charsOk) {
     header("Location: ../../../Admin/admin.php?p=player&uid=$uid&e=invalid");
     exit;
 }


### PR DESCRIPTION
Two admin-panel bug fixes found while testing the CSRF work:

1. **Route Edit Password / Edit Protection** — both pages are linked from
   playerinfo.tpl (?p=editPassword / ?p=editProtection) but were never in
   admin_validated_page()'s whitelist, so admin.php fell back to search.tpl and
   the form never showed. Added to the whitelist + a switch case for the
   breadcrumb (the templates resolve $uid/$user themselves, like editSitter).
2. **Align editUsername validation with sign-up** — it used its own regex
   ([a-zA-Z0-9_]+), rejecting dashes/dots/spaces that registration accepts when
   USRNM_SPECIAL is on (Account.php, #184), so an admin couldn't rename a player
   to an otherwise-valid name (failure was silent). Reuses the same USRNM_* rule
   and length bounds.

> Heads-up @Shadowss: point 2 touches `GameEngine/Admin/Mods/editUsername.php`,
> which is also modified by `Ferywir:fix/admin-csrf-mods-players` (the CSRF PR) —
> but in a different region (CSRF guard at the top there, validation block here).
> Independent changes; whichever merges first, the other may need a trivial
> rebase (no logical conflict).