### PR TITLE
fix(admin): verify CSRF token in troop admin Mods [#139]

### DIFF
--- a/Admin/Templates/addABTroops.tpl
+++ b/Admin/Templates/addABTroops.tpl
@@ -53,6 +53,7 @@ if(isset($id)){
 
 <div class="ab-wrap">
 <form action="../GameEngine/Admin/Mods/addABTroops.php" method="POST">
+<?php echo csrf_field(); ?>
 <input type="hidden" name="id" value="<?php echo $_GET['did']; ?>">
 <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 

--- a/Admin/Templates/addTroops.tpl
+++ b/Admin/Templates/addTroops.tpl
@@ -55,6 +55,7 @@ if(isset($id)){
 
 <div class="addtroops-wrap">
 <form action="../GameEngine/Admin/Mods/addTroops.php" method="POST">
+<?php echo csrf_field(); ?>
 <input type="hidden" name="id" value="<?php echo $_GET['did']; ?>">
 <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 

--- a/GameEngine/Admin/Mods/addABTroops.php
+++ b/GameEngine/Admin/Mods/addABTroops.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once __DIR__ . "/../../Database.php";
 
 /* ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/addTroops.php
+++ b/GameEngine/Admin/Mods/addTroops.php
@@ -19,6 +19,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die(defined('ACCESS_DENIED_ADMIN') ? ACCESS_DENIED_ADMIN : 'Access Denied: You are not Admin!');
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once __DIR__ . "/../../Database.php";
 include_once __DIR__ . "/../../Technology.php";
 include_once __DIR__ . "/../../Data/unitdata.php";


### PR DESCRIPTION
Part of #139, follow-up to #253/#256. The troop admin Mods are POSTed to
directly, bypassing admin.php's central csrf_verify(). Adds csrf_verify()
(after the admin access check, via the shared GameEngine/Admin/csrf.php) and
csrf_field() in the matching forms for addTroops and addABTroops. Tested
in-game (both save correctly with the token).