### PR TITLE
fix(admin): verify CSRF token in village admin Mods [#139]

### DIFF
--- a/Admin/Templates/editResources.tpl
+++ b/Admin/Templates/editResources.tpl
@@ -44,6 +44,7 @@ if($id){
 
 <div class="res-wrap">
   <form action="../GameEngine/Admin/Mods/editResources.php" method="POST">
+    <?php echo csrf_field(); ?>
     <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 	<input type="hidden" name="did" id="did" value="<?php echo $_GET['did']; ?>">
     

--- a/Admin/Templates/editVillage.tpl
+++ b/Admin/Templates/editVillage.tpl
@@ -45,6 +45,7 @@ if(isset($id)) { include("search2.tpl"); ?>
 </style>
 <div class="village-page">
 <form action="../GameEngine/Admin/Mods/editBuildings.php" method="POST">
+<?php echo csrf_field(); ?>
 <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 <input type="hidden" name="id" value="<?php echo $_GET['did']; ?>">
 

--- a/Admin/Templates/village.tpl
+++ b/Admin/Templates/village.tpl
@@ -119,6 +119,7 @@ if(isset($id)){
     <tr><td class="label">Owner</td><td><a href="admin.php?p=player&uid=<?php echo $village['owner']; ?>" style="color:#2563eb;font-weight:600"><?php echo $user['username']; ?></a></td>
       <td style="text-align:right">
         <form action="../GameEngine/Admin/Mods/editVillageOwner.php" method="POST" style="display:flex;gap:4px;align-items:center;justify-content:flex-end">
+          <?php echo csrf_field(); ?>
           <input type="hidden" name="did" value="<?php echo $_GET['did']; ?>">
           <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
           <input class="input-mini" type="text" name="newowner" value="<?php echo $user['id']; ?>" style="width:65px">
@@ -130,6 +131,7 @@ if(isset($id)){
     </tr>
         <tr><td class="label">Name</td><td colspan="2">
           <form action="../GameEngine/Admin/Mods/renameVillage.php" method="POST" style="display:flex;gap:4px">
+            <?php echo csrf_field(); ?>
             <input type="hidden" name="did" value="<?php echo $_GET['did']; ?>">
             <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
             <input class="input-mini" type="text" name="villagename" value="<?php echo $village['name']; ?>" style="flex:1">

--- a/GameEngine/Admin/Mods/editBuildings.php
+++ b/GameEngine/Admin/Mods/editBuildings.php
@@ -18,6 +18,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editResources.php
+++ b/GameEngine/Admin/Mods/editResources.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editVillageOwner.php
+++ b/GameEngine/Admin/Mods/editVillageOwner.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/renameVillage.php
+++ b/GameEngine/Admin/Mods/renameVillage.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #139, follow-up to #253/#256/#258. The village admin Mods are POSTed
to directly, bypassing admin.php's central csrf_verify(). Adds csrf_verify()
(after the admin access check, via the shared GameEngine/Admin/csrf.php) and
csrf_field() in the matching forms for editVillageOwner, renameVillage,
editBuildings and editResources. Tested in-game (all four save correctly with
the token).