### PR TITLE
fix(admin): verify CSRF token in alliance/medal admin Mods [#139]

### DIFF
--- a/Admin/Templates/allymedals.tpl
+++ b/Admin/Templates/allymedals.tpl
@@ -63,6 +63,7 @@ $varmedal = $database->getProfileMedalAlly($_GET['aid']);
         <td><img src="../gpack/travian_default/img/t/<?=$medal['img']?>.jpg"></td>
         <td>
           <form action="../GameEngine/Admin/Mods/delallymedal.php" method="POST" style="margin:0">
+            <?php echo csrf_field(); ?>
             <input type="hidden" name="aid" value="<?=$_GET['aid']?>">
             <input type="hidden" name="admid" value="<?=$_SESSION['id']?>">
             <button type="submit" name="medalid" value="<?=$medal['id']?>" class="medal-del" title="Delete">
@@ -81,6 +82,7 @@ $varmedal = $database->getProfileMedalAlly($_GET['aid']);
         <td>Delete All</td>
         <td>
           <form action="../GameEngine/Admin/Mods/delallymedalbyaid.php" method="POST" style="margin:0">
+            <?php echo csrf_field(); ?>
             <input type="hidden" name="admid" value="<?=$_SESSION['id']?>">
             <input type="hidden" name="aid" value="<?=$_GET['aid']?>">
             <button type="submit" class="medal-del" title="Delete All">

--- a/Admin/Templates/delAli.tpl
+++ b/Admin/Templates/delAli.tpl
@@ -44,6 +44,7 @@ $members = $database->getAllMember($aid);
         <div class="warn">⚠ All members will be removed from the alliance, permissions, diplomacy, logs and the alliance forum will be deleted. The action is irreversible!</div>
 
         <form method="POST" action="../GameEngine/Admin/Mods/delAli.php" onsubmit="return confirm('Last warning: DELETE PERMANENTLY?');">
+            <?php echo csrf_field(); ?>
             <input type="hidden" name="aid" value="<?php echo $aid;?>">
             <input type="hidden" name="admid" value="<?php echo $_SESSION['id'];?>">
             <button type="submit" class="btn del">YES, DELETE</button>

--- a/Admin/Templates/delallymedal.tpl
+++ b/Admin/Templates/delallymedal.tpl
@@ -63,6 +63,7 @@ $nummedals = $sql['Total'];
 
 
 <form action="../GameEngine/Admin/Mods/delallymedalbyweek.php" method="POST">
+<?php echo csrf_field(); ?>
 <input type="hidden" name="admid" id="admid" value="<?php echo $_SESSION['id']; ?>">
 <table id="member">
 	<thead>

--- a/Admin/Templates/delmedal.tpl
+++ b/Admin/Templates/delmedal.tpl
@@ -64,6 +64,7 @@ $nummedals = $sql['Total'];
 
 
 <form action="../GameEngine/Admin/Mods/deletemedalbyweek.php" method="POST">
+<?php echo csrf_field(); ?>
 <input type="hidden" name="admid" id="admid" value="<?php echo $_SESSION['id']; ?>">
 <table id="member">
 	<thead>

--- a/Admin/Templates/editAli.tpl
+++ b/Admin/Templates/editAli.tpl
@@ -59,6 +59,7 @@ textarea{width:100%;box-sizing:border-box;min-height:120px;padding:8px;border:1p
     </div>
 
     <form action="../GameEngine/Admin/Mods/editAli.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="aid" value="<?php echo $aid; ?>">
         <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 

--- a/Admin/Templates/playermedals.tpl
+++ b/Admin/Templates/playermedals.tpl
@@ -56,6 +56,7 @@
           <td><img class="medal" src="../gpack/travian_default/img/t/'.$medal['img'].'.jpg"></td>
           <td>
             <form action="../GameEngine/Admin/Mods/medals.php" method="POST" style="margin:0">
+              '.csrf_field().'
               <input type="hidden" name="uid" value="'.$_GET['uid'].'">
               <input type="hidden" name="medalid" value="'.$medal['id'].'">
               <button type="submit" class="medals-del" title="Delete medal">
@@ -71,6 +72,7 @@
       echo '<tr class="avg-row"><td style="text-align:left"><b>Average Rank</b></td><td>'.$average.'</td><td></td><td></td><td>Delete All</td>
         <td>
           <form action="../GameEngine/Admin/Mods/medals.php" method="POST" style="margin:0">
+            '.csrf_field().'
             <input type="hidden" name="uid" value="'.$_GET['uid'].'">
             <input type="hidden" name="userid" value="'.$id.'">
             <button type="submit" class="medals-del" title="Delete all medals">

--- a/GameEngine/Admin/Mods/delAli.php
+++ b/GameEngine/Admin/Mods/delAli.php
@@ -14,6 +14,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/delallymedal.php
+++ b/GameEngine/Admin/Mods/delallymedal.php
@@ -16,6 +16,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 // ---------------------------------------------------------------------------
 // Autoloader path
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/delallymedalbyaid.php
+++ b/GameEngine/Admin/Mods/delallymedalbyaid.php
@@ -16,6 +16,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 // ---------------------------------------------------------------------------
 // Autoloader path
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/delallymedalbyweek.php
+++ b/GameEngine/Admin/Mods/delallymedalbyweek.php
@@ -16,6 +16,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 // ---------------------------------------------------------------------------
 // Autoloader path
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/deletemedalbyweek.php
+++ b/GameEngine/Admin/Mods/deletemedalbyweek.php
@@ -16,6 +16,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 // ---------------------------------------------------------------------------
 // Autoloader path
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editAli.php
+++ b/GameEngine/Admin/Mods/editAli.php
@@ -16,6 +16,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/medals.php
+++ b/GameEngine/Admin/Mods/medals.php
@@ -11,6 +11,12 @@
 #################################################################################
 if (!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../Account.php");
 
 // go max 5 levels up - we don't have folders that go deeper than that


### PR DESCRIPTION
Part of #139, follow-up to #253/#256/#258/#259. The alliance/medal admin Mods
are POSTed to directly, bypassing admin.php's central csrf_verify(). Adds
csrf_verify() (after the admin access check, via the shared
GameEngine/Admin/csrf.php) and csrf_field() in the matching forms for editAli,
delAli, medals, delallymedal, delallymedalbyaid, delallymedalbyweek and
deletemedalbyweek. Tested in-game.

> Note: this PR and the medals-log fix PR both touch
> GameEngine/Admin/Mods/medals.php in different regions (CSRF guard at the top
> here vs the admin-log block at the bottom there). Independent; whichever merges
> first, the other may need a trivial rebase.