### PR TITLE
fix(admin): repair broken admin-log variables in medals Mod

### DIFF
--- a/GameEngine/Admin/Mods/medals.php
+++ b/GameEngine/Admin/Mods/medals.php
@@ -34,10 +34,12 @@ elseif(isset($_POST['userid']) && !empty($_POST['userid']) && is_numeric($_POST[
     mysqli_query($database->dblink, "UPDATE ".TB_PREFIX."medal set del = 1 WHERE userid = ".$userID."");
 }
 
-$admidID = (int) $_SESSION['id'];
-$name = $database->getUserField($adminID, "name", 0);
+$admid = (int) $_SESSION['id'];
+$uid   = (int) ($_POST['uid'] ?? 0);
+$name  = $database->escape((string) $database->getUserField($uid, "username", 0));
+$medalLogId = isset($medalID) ? $medalID : 0;
 //TODO: Make a dedicated method for logging
-mysqli_query($database->dblink, "INSERT INTO ".TB_PREFIX."admin_log values (0, $admid, 'Deleted medal id [#".$medalid."] from the user <a href=\'admin.php?p=player&uid=$uid\'>$name</a> ',".time().")");
+mysqli_query($database->dblink, "INSERT INTO ".TB_PREFIX."admin_log values (0, $admid, 'Deleted medal id [#".$medalLogId."] from the user <a href=\'admin.php?p=player&uid=$uid\'>$name</a> ',".time().")");
 
-header("Location: ../../../Admin/admin.php?p=player&uid=".$_POST['uid']."");
+header("Location: ../../../Admin/admin.php?p=player&uid=".$uid);
 ?>


### PR DESCRIPTION
The post-delete admin-log block in medals.php referenced variables that were
never defined ($admid/$adminID/$medalid/$uid), so on PHP 8.1+ (mysqli throws on
error) the malformed INSERT raised an uncaught mysqli_sql_exception → HTTP 500
after the medal was already deleted. Use the correct ids ($admid from session,
$uid from POST), look up the target player's username (escaped), and redirect to
the sanitized $uid. Pre-existing bug, unrelated to the CSRF work. Tested in-game.

> Note: this PR and the alliance/medal CSRF PR both touch
> GameEngine/Admin/Mods/medals.php in different regions (admin-log block at the
> bottom here vs CSRF guard at the top there). Independent; whichever merges
> first, the other may need a trivial rebase.