### PR TITLE
fix(admin): verify CSRF token in message admin Mods [#139]

### DIFF
--- a/Admin/Templates/Newmessage.tpl
+++ b/Admin/Templates/Newmessage.tpl
@@ -54,6 +54,7 @@ $user = $database->getUserArray($id,1);
     </div>
     
     <form method="post" action="../GameEngine/Admin/Mods/sendMessage.php" name="msg">
+      <?php echo csrf_field(); ?>
       <div class="msg-body">
         <input type="hidden" name="uid" value="<?php echo $id; ?>">
         

--- a/Admin/Templates/massmessage.tpl
+++ b/Admin/Templates/massmessage.tpl
@@ -66,6 +66,7 @@ $_SESSION['mass_color']   = $_SESSION['mass_color'] ?? 'black';
       <b>Subject:</b> <span style="color:<?=$_SESSION['mass_color']?>"><?=htmlspecialchars($_SESSION['mass_subject'])?></span>
     </div>
     <form action="../GameEngine/Admin/Mods/massmessage.php" method="POST" class="massmsg-form">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="admid" value="<?=$id?>">
       <input type="hidden" name="action" value="execute">
       <button type="submit" name="confirm" value="Yes" style="background:#27ae60">✓ Yes, Send</button>
@@ -80,6 +81,7 @@ $_SESSION['mass_color']   = $_SESSION['mass_color'] ?? 'black';
 
 <?php else:?>
     <form action="../GameEngine/Admin/Mods/massmessage.php" method="POST" class="massmsg-form">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="admid" value="<?=$id?>">
       <input type="hidden" name="action" value="prepare">
 

--- a/Admin/Templates/sysmessage.tpl
+++ b/Admin/Templates/sysmessage.tpl
@@ -68,6 +68,7 @@ $_SESSION['sys_color']   = $_SESSION['sys_color'] ?? 'black';
     </div>
 
     <form action="../GameEngine/Admin/Mods/sysmessage.php" method="POST" class="sysmsg-form">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="admid" value="<?=$id?>">
         <input type="hidden" name="action" value="execute">
 
@@ -84,7 +85,7 @@ $_SESSION['sys_color']   = $_SESSION['sys_color'] ?? 'black';
 <?php else: ?>
 
     <form action="../GameEngine/Admin/Mods/sysmessage.php" method="POST" class="sysmsg-form">
-
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="admid" value="<?=$id?>">
         <input type="hidden" name="action" value="prepare">
 

--- a/GameEngine/Admin/Mods/massmessage.php
+++ b/GameEngine/Admin/Mods/massmessage.php
@@ -20,6 +20,11 @@ if (!isset($_SESSION['access']) || $_SESSION['access'] < ADMIN) {
     die("Access Denied");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 /*
 |--------------------------------------------------------------------------
 | PREPARE

--- a/GameEngine/Admin/Mods/sendMessage.php
+++ b/GameEngine/Admin/Mods/sendMessage.php
@@ -18,6 +18,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/sysmessage.php
+++ b/GameEngine/Admin/Mods/sysmessage.php
@@ -24,6 +24,11 @@ if (!isset($_SESSION['access']) || $_SESSION['access'] < ADMIN) {
     die("Access Denied");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 // ---------------------------------------------------------------------------
 // Resolve project root (so we can read/write Templates/*.tpl)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #139, follow-up to #253/#256/#258/#259/#261. The message admin Mods are
POSTed to directly, bypassing admin.php's central csrf_verify(). Adds
csrf_verify() (after the admin access check, via the shared
GameEngine/Admin/csrf.php) and csrf_field() in the matching forms for
sendMessage, massmessage and sysmessage (the mass/sys templates each have a
prepare and an execute form). Tested in-game (single IGM, mass message and
system message, both prepare and execute steps).