### PR TITLE
fix(admin): verify CSRF token in server-settings admin Mods [#139]

### DIFF
--- a/Admin/Templates/debug_log.tpl
+++ b/Admin/Templates/debug_log.tpl
@@ -89,6 +89,7 @@ $autoOff = (int)($cfg['auto_off_hours'] ?? 0);
       <span>Log size: <b><?php echo number_format($logSize / 1024, 1); ?> KB</b></span>
     </div>
     <form action="../GameEngine/Admin/Mods/debugLog.php" method="POST" style="display:inline">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="do" value="toggle">
       <input type="hidden" name="active" value="<?php echo $isOn ? 0 : 1; ?>">
       <button type="submit" class="dbg-btn <?php echo $isOn ? 'red' : 'green'; ?>">
@@ -101,6 +102,7 @@ $autoOff = (int)($cfg['auto_off_hours'] ?? 0);
   <div class="dbg-card">
     <h3>Capture settings</h3>
     <form action="../GameEngine/Admin/Mods/debugLog.php" method="POST">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="do" value="save">
       <div class="dbg-row">
         <label><input type="checkbox" name="lvl_warning"    <?php echo !empty($cfg['lvl_warning'])    ? 'checked' : ''; ?>> Warnings</label>
@@ -127,6 +129,7 @@ $autoOff = (int)($cfg['auto_off_hours'] ?? 0);
       <a class="dbg-btn" href="../GameEngine/Admin/Mods/debugLog.php?do=download">⬇ Download full log</a>
       <form action="../GameEngine/Admin/Mods/debugLog.php" method="POST" style="display:inline"
             onsubmit="return confirm('Clear the debug log file?');">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="do" value="clear">
         <button type="submit" class="dbg-btn red">🗑 Clear log</button>
       </form>

--- a/Admin/Templates/editAdminInfo.tpl
+++ b/Admin/Templates/editAdminInfo.tpl
@@ -58,6 +58,7 @@ if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
     <div class="config-title"><?php echo SERV_CONFIG ?></div>
     
     <form action="../GameEngine/Admin/Mods/editAdminInfo.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="id" id="id" value="<?php echo $_SESSION['id']; ?>">
         
         <div class="config-card">

--- a/Admin/Templates/editExtraSet.tpl
+++ b/Admin/Templates/editExtraSet.tpl
@@ -58,6 +58,7 @@ if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
     <div class="config-title"><?php echo SERV_CONFIG ?></div>
     
     <form action="../GameEngine/Admin/Mods/editExtraSet.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="id" id="id" value="<?php echo $_SESSION['id']; ?>">
         
         <div class="config-card">

--- a/Admin/Templates/editLogSet.tpl
+++ b/Admin/Templates/editLogSet.tpl
@@ -58,6 +58,7 @@ if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
     <div class="config-title"><?php echo SERV_CONFIG ?></div>
     
     <form action="../GameEngine/Admin/Mods/editLogSet.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="id" id="id" value="<?php echo $_SESSION['id']; ?>">
         
         <div class="config-card">

--- a/Admin/Templates/editNewFunctions.tpl
+++ b/Admin/Templates/editNewFunctions.tpl
@@ -58,6 +58,7 @@ if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
     <div class="config-title"><?php echo SERV_CONFIG ?></div>
     
     <form action="../GameEngine/Admin/Mods/editNewFunctions.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="id" id="id" value="<?php echo $_SESSION['id']; ?>">
         
         <div class="config-card">

--- a/Admin/Templates/editNewsboxSet.tpl
+++ b/Admin/Templates/editNewsboxSet.tpl
@@ -58,6 +58,7 @@ if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
     <div class="config-title"><?php echo SERV_CONFIG ?></div>
     
     <form action="../GameEngine/Admin/Mods/editNewsboxSet.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="id" id="id" value="<?php echo $_SESSION['id']; ?>">
         
         <div class="config-card">

--- a/Admin/Templates/editOverall.tpl
+++ b/Admin/Templates/editOverall.tpl
@@ -64,6 +64,7 @@ if($id){
     </div>
 
     <form action="../GameEngine/Admin/Mods/editOverall.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
         <input type="hidden" name="uid" value="<?php echo $uid; ?>">
         <input type="hidden" name="id" value="<?php echo $id; ?>">

--- a/Admin/Templates/editPlusSet.tpl
+++ b/Admin/Templates/editPlusSet.tpl
@@ -59,6 +59,7 @@ if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
     <div class="config-title"><?php echo PLUS_CONFIGURATION ?></div>
     
     <form action="../GameEngine/Admin/Mods/editPlusSet.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="id" id="id" value="<?php echo $_SESSION['id']; ?>">
         
         <div class="config-card">

--- a/Admin/Templates/editServerSet.tpl
+++ b/Admin/Templates/editServerSet.tpl
@@ -64,6 +64,7 @@ function refresh(tz) {
     <div class="config-title"><?php echo SERV_CONFIG ?></div>
     
     <form action="../GameEngine/Admin/Mods/editServerSet.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="id" id="id" value="<?php echo $_SESSION['id']; ?>">
         
         <div class="config-card">

--- a/Admin/Templates/editWeek.tpl
+++ b/Admin/Templates/editWeek.tpl
@@ -66,6 +66,7 @@ if($id){
     </div>
 
     <form action="../GameEngine/Admin/Mods/editWeek.php" method="POST">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
         <input type="hidden" name="uid" value="<?php echo $uid; ?>">
         <input type="hidden" name="id" value="<?php echo $id; ?>">

--- a/GameEngine/Admin/Mods/debugLog.php
+++ b/GameEngine/Admin/Mods/debugLog.php
@@ -17,6 +17,15 @@
 if(!isset($_SESSION)) session_start();
 if(($_SESSION['access'] ?? 0) < 9) die("Access denied: You are not Admin!");
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()). Only POST
+// requests mutate state; the ?do=download link is a plain GET (a read) and must
+// not be blocked, so guard the check on the request method.
+require_once(__DIR__ . '/../csrf.php');
+if (($_SERVER['REQUEST_METHOD'] ?? '') === 'POST') {
+    csrf_verify();
+}
+
 include_once("../../Database.php");
 
 // Resolve project root (max 5 levels up), like the rest of the codebase.

--- a/GameEngine/Admin/Mods/editAdminInfo.php
+++ b/GameEngine/Admin/Mods/editAdminInfo.php
@@ -11,6 +11,12 @@
 
 if(!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 

--- a/GameEngine/Admin/Mods/editExtraSet.php
+++ b/GameEngine/Admin/Mods/editExtraSet.php
@@ -11,6 +11,12 @@
 
 if(!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 

--- a/GameEngine/Admin/Mods/editLogSet.php
+++ b/GameEngine/Admin/Mods/editLogSet.php
@@ -11,6 +11,12 @@
 
 if(!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 

--- a/GameEngine/Admin/Mods/editNewFunctions.php
+++ b/GameEngine/Admin/Mods/editNewFunctions.php
@@ -11,6 +11,12 @@
 
 if(!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 

--- a/GameEngine/Admin/Mods/editNewsboxSet.php
+++ b/GameEngine/Admin/Mods/editNewsboxSet.php
@@ -11,6 +11,12 @@
 
 if(!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 

--- a/GameEngine/Admin/Mods/editOverall.php
+++ b/GameEngine/Admin/Mods/editOverall.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editPlusSet.php
+++ b/GameEngine/Admin/Mods/editPlusSet.php
@@ -11,6 +11,12 @@
 
 if(!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../Database.php");
 include_once("../../config.php");
 $id = (int) $_POST['id'];

--- a/GameEngine/Admin/Mods/editServerSet.php
+++ b/GameEngine/Admin/Mods/editServerSet.php
@@ -11,6 +11,12 @@
 
 if(!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die(ACCESS_DENIED_ADMIN);
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 

--- a/GameEngine/Admin/Mods/editWeek.php
+++ b/GameEngine/Admin/Mods/editWeek.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #139, follow-up to #253/#256/#258/#259/#261/#264. The server-settings
admin Mods are POSTed to directly, bypassing admin.php's central csrf_verify().
Adds csrf_verify() (after the admin access check, via the shared
GameEngine/Admin/csrf.php) and csrf_field() in the matching forms for
editServerSet, editAdminInfo, editLogSet, editNewFunctions, editNewsboxSet,
editExtraSet, editOverall, editPlusSet, editWeek and debugLog. debugLog only
verifies on POST so its ?do=download GET link (a read) keeps working. Rebased
onto the latest master (Fix Server Settings in Admin Panel). Tested in-game.