### PR TITLE
fix(admin): verify CSRF token in maintenance admin Mods [#139]

### DIFF
--- a/Admin/Templates/cleanban.tpl
+++ b/Admin/Templates/cleanban.tpl
@@ -30,6 +30,7 @@
 </style>
 
 <form action="../GameEngine/Admin/Mods/mainteneceCleanBanData.php" method="POST" onsubmit="return confirm('TRUNCATE banlist? This cannot be undone!')">
+<?php echo csrf_field(); ?>
 <input type="hidden" name="admid" value="<?=$_SESSION['id']?>">
 <div class="clean-card">
   <div class="clean-head">Clear – Banlist - Data</div>

--- a/Admin/Templates/deletion.tpl
+++ b/Admin/Templates/deletion.tpl
@@ -78,6 +78,7 @@ if(isset($_GET['uid']) && (int)$_GET['uid'] > 0) {
     </div>
 
     <form action="../GameEngine/Admin/Mods/delUser.php" method="post" onsubmit="return confirm('ESTI SIGUR? Se va sterge tot: sate, trupe, rapoarte!')">
+        <?php echo csrf_field(); ?>
         <input type="hidden" name="uid" value="<?php echo $target['id']; ?>">
         <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 

--- a/Admin/Templates/maintenenceResetGold.tpl
+++ b/Admin/Templates/maintenenceResetGold.tpl
@@ -55,6 +55,7 @@ if($_SESSION['access'] < ADMIN) die("Access Denied: You are not Admin!");
     </div>
 
     <form action="../GameEngine/Admin/Mods/mainteneceResetGold.php" method="POST" class="resetgold-form" onsubmit="return confirm('Are you SURE you want to reset gold to ALL players?');">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
       <button type="submit">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M8 6V4h8v2m-1 0v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V6h10z" stroke="#fff" stroke-width="2" stroke-linecap="round"/></svg>

--- a/Admin/Templates/maintenenceResetPlus.tpl
+++ b/Admin/Templates/maintenenceResetPlus.tpl
@@ -55,6 +55,7 @@ if($_SESSION['access'] < ADMIN) die("Access Denied: You are not Admin!");
     </div>
 
     <form action="../GameEngine/Admin/Mods/mainteneceResetPlus.php" method="POST" class="resetplus-form" onsubmit="return confirm('Are you SURE you want to reset the Plus to ALL players?');">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
       <button type="submit">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M8 6V4h8v2m-1 0v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V6h10z" stroke="#fff" stroke-width="2" stroke-linecap="round"/></svg>

--- a/Admin/Templates/maintenenceResetPlusBonus.tpl
+++ b/Admin/Templates/maintenenceResetPlusBonus.tpl
@@ -67,6 +67,7 @@ if($_SESSION['access'] < ADMIN) die("Access Denied: You are not Admin!");
     </div>
 
     <form action="../GameEngine/Admin/Mods/mainteneceResetPlusBonus.php" method="POST" class="resetres-form" onsubmit="return confirm('Are you SURE you want to reset resource bonuses?');">
+      <?php echo csrf_field(); ?>
       <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
       <button type="submit">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M8 6V4h8v2m-1 0v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V6h10z" stroke="#fff" stroke-width="2" stroke-linecap="round"/></svg>

--- a/GameEngine/Admin/Mods/cp.php
+++ b/GameEngine/Admin/Mods/cp.php
@@ -10,6 +10,12 @@
 #################################################################################
 if (!isset($_SESSION)) session_start();
 if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
+
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // go max 5 levels up - we don't have folders that go deeper than that

--- a/GameEngine/Admin/Mods/delUser.php
+++ b/GameEngine/Admin/Mods/delUser.php
@@ -14,6 +14,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/giveResBonus.php
+++ b/GameEngine/Admin/Mods/giveResBonus.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceBan.php
+++ b/GameEngine/Admin/Mods/mainteneceBan.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceCleanBanData.php
+++ b/GameEngine/Admin/Mods/mainteneceCleanBanData.php
@@ -16,6 +16,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceResetGold.php
+++ b/GameEngine/Admin/Mods/mainteneceResetGold.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceResetPlus.php
+++ b/GameEngine/Admin/Mods/mainteneceResetPlus.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceResetPlusBonus.php
+++ b/GameEngine/Admin/Mods/mainteneceResetPlusBonus.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceUnban.php
+++ b/GameEngine/Admin/Mods/mainteneceUnban.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/recalcWH.php
+++ b/GameEngine/Admin/Mods/recalcWH.php
@@ -17,6 +17,11 @@ if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
     die("Access Denied: You are not Admin!");
 }
 
+// Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
+// itself (it does not go through admin.php's central csrf_verify()).
+require_once(__DIR__ . '/../csrf.php');
+csrf_verify();
+
 include_once("../../config.php");
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #139, follow-up to #253/#256/#258/#259/#261/#264/#268. The maintenance
admin Mods are POSTed to directly, bypassing admin.php's central csrf_verify().
Adds csrf_verify() (after the admin access check, via the shared
GameEngine/Admin/csrf.php) and csrf_field() in the matching forms.

Mods with a form: mainteneceCleanBanData, mainteneceResetGold,
mainteneceResetPlus, mainteneceResetPlusBonus (+ their templates), and delUser
(already password-protected; token added as defense-in-depth).

Mods with no UI form (mainteneceBan, mainteneceUnban, recalcWH, giveResBonus,
cp) are reachable only by a direct/forged POST: csrf_verify() closes those live
CSRF holes outright (no legitimate caller, nothing to break).

Tested in-game (the 5 forms).