### PR TITLE
fix(admin): escape reflected request params in admin templates [#139]

### DIFF
--- a/Admin/Templates/addABTroops.tpl
+++ b/Admin/Templates/addABTroops.tpl
@@ -54,7 +54,7 @@ if(isset($id)){
 <div class="ab-wrap">
 <form action="../GameEngine/Admin/Mods/addABTroops.php" method="POST">
 <?php echo csrf_field(); ?>
-<input type="hidden" name="id" value="<?php echo $_GET['did']; ?>">
+<input type="hidden" name="id" value="<?php echo (int)($_GET['did'] ?? 0); ?>">
 <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 
 <div class="ab-card">
@@ -75,7 +75,7 @@ if(isset($id)){
   </div>
   
   <div class="ab-foot">
-    <button type="button" class="btn btn-back" onclick="location.href='admin.php?p=village&did=<?=$_GET['did']?>'">
+    <button type="button" class="btn btn-back" onclick="location.href='admin.php?p=village&did=<?=(int)($_GET['did'] ?? 0)?>'">
       <svg viewBox="0 0 24 24"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Back
     </button>
     <button type="submit" name="save" class="btn btn-save">

--- a/Admin/Templates/addTroops.tpl
+++ b/Admin/Templates/addTroops.tpl
@@ -56,7 +56,7 @@ if(isset($id)){
 <div class="addtroops-wrap">
 <form action="../GameEngine/Admin/Mods/addTroops.php" method="POST">
 <?php echo csrf_field(); ?>
-<input type="hidden" name="id" value="<?php echo $_GET['did']; ?>">
+<input type="hidden" name="id" value="<?php echo (int)($_GET['did'] ?? 0); ?>">
 <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 
 <div class="addtroops-card">
@@ -79,7 +79,7 @@ if(isset($id)){
   </div>
   
   <div class="addtroops-foot">
-    <button type="button" class="btn btn-back" onclick="location.href='admin.php?p=village&did=<?=$_GET['did']?>'">
+    <button type="button" class="btn btn-back" onclick="location.href='admin.php?p=village&did=<?=(int)($_GET['did'] ?? 0)?>'">
       <svg viewBox="0 0 24 24"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>Back
     </button>
     <button type="submit" name="save" class="btn btn-save">

--- a/Admin/Templates/allymedals.tpl
+++ b/Admin/Templates/allymedals.tpl
@@ -64,7 +64,7 @@ $varmedal = $database->getProfileMedalAlly($_GET['aid']);
         <td>
           <form action="../GameEngine/Admin/Mods/delallymedal.php" method="POST" style="margin:0">
             <?php echo csrf_field(); ?>
-            <input type="hidden" name="aid" value="<?=$_GET['aid']?>">
+            <input type="hidden" name="aid" value="<?=(int)($_GET['aid'] ?? 0)?>">
             <input type="hidden" name="admid" value="<?=$_SESSION['id']?>">
             <button type="submit" name="medalid" value="<?=$medal['id']?>" class="medal-del" title="Delete">
               <svg viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
@@ -84,7 +84,7 @@ $varmedal = $database->getProfileMedalAlly($_GET['aid']);
           <form action="../GameEngine/Admin/Mods/delallymedalbyaid.php" method="POST" style="margin:0">
             <?php echo csrf_field(); ?>
             <input type="hidden" name="admid" value="<?=$_SESSION['id']?>">
-            <input type="hidden" name="aid" value="<?=$_GET['aid']?>">
+            <input type="hidden" name="aid" value="<?=(int)($_GET['aid'] ?? 0)?>">
             <button type="submit" class="medal-del" title="Delete All">
               <svg viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
             </button>

--- a/Admin/Templates/editAccess.tpl
+++ b/Admin/Templates/editAccess.tpl
@@ -30,7 +30,7 @@ if(isset($_GET['uid']))
 	<form action="../GameEngine/Admin/Mods/editAccess.php" method="POST">
 		<?php echo csrf_field(); ?>
 		<input type="hidden" name="admid" id="admid" value="<?php echo $_SESSION['id']; ?>">
-		<input type="hidden" name="uid" id="uid" value="<?php echo $_GET['uid']; ?>">
+		<input type="hidden" name="uid" id="uid" value="<?php echo (int)($_GET['uid'] ?? 0); ?>">
 		<table id="member" style="width:300px;">
 			<thead>
 				<tr>

--- a/Admin/Templates/editResources.tpl
+++ b/Admin/Templates/editResources.tpl
@@ -46,7 +46,7 @@ if($id){
   <form action="../GameEngine/Admin/Mods/editResources.php" method="POST">
     <?php echo csrf_field(); ?>
     <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
-	<input type="hidden" name="did" id="did" value="<?php echo $_GET['did']; ?>">
+	<input type="hidden" name="did" id="did" value="<?php echo (int)($_GET['did'] ?? 0); ?>">
     
     <div class="res-card">
       <div class="res-head">Modify Resources — <?php echo $village['name']; ?> (<?php echo $coor['x']; ?>|<?php echo $coor['y']; ?>)</div>
@@ -82,7 +82,7 @@ if($id){
       </table>
       
       <div class="res-actions">
-        <a href="../Admin/admin.php?p=village&did=<?php echo $_GET['did'];?>" class="btn-back">← Back to village</a>
+        <a href="../Admin/admin.php?p=village&did=<?php echo (int)($_GET['did'] ?? 0);?>" class="btn-back">← Back to village</a>
         <button type="submit" class="btn-save">Save Changes</button>
       </div>
     </div>

--- a/Admin/Templates/editVillage.tpl
+++ b/Admin/Templates/editVillage.tpl
@@ -47,7 +47,7 @@ if(isset($id)) { include("search2.tpl"); ?>
 <form action="../GameEngine/Admin/Mods/editBuildings.php" method="POST">
 <?php echo csrf_field(); ?>
 <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
-<input type="hidden" name="id" value="<?php echo $_GET['did']; ?>">
+<input type="hidden" name="id" value="<?php echo (int)($_GET['did'] ?? 0); ?>">
 
 <div class="vcard">
   <div class="vhead">Edit Village – <?php echo htmlspecialchars($village['name']); ?> (<?php echo $coor['x'].'|'.$coor['y']; ?>)

--- a/Admin/Templates/massmessage.tpl
+++ b/Admin/Templates/massmessage.tpl
@@ -76,7 +76,7 @@ $_SESSION['mass_color']   = $_SESSION['mass_color'] ?? 'black';
 <?php elseif(isset($_GET['sending'])):?>
     <div style="text-align:center;padding:30px">
       <div style="font-size:16px;margin-bottom:10px">Sending messages...</div>
-      <div style="color:#666"><?=$_GET['msg']?? ''?></div>
+      <div style="color:#666"><?=e($_GET['msg'] ?? '')?></div>
     </div>
 
 <?php else:?>

--- a/Admin/Templates/playermedals.tpl
+++ b/Admin/Templates/playermedals.tpl
@@ -57,7 +57,7 @@
           <td>
             <form action="../GameEngine/Admin/Mods/medals.php" method="POST" style="margin:0">
               '.csrf_field().'
-              <input type="hidden" name="uid" value="'.$_GET['uid'].'">
+              <input type="hidden" name="uid" value="'.(int)($_GET['uid'] ?? 0).'">
               <input type="hidden" name="medalid" value="'.$medal['id'].'">
               <button type="submit" class="medals-del" title="Delete medal">
                 <svg viewBox="0 0 24 24"><path d="M3 6h18M8 6V4h8v2m-1 0v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V6h10z"/></svg>
@@ -73,7 +73,7 @@
         <td>
           <form action="../GameEngine/Admin/Mods/medals.php" method="POST" style="margin:0">
             '.csrf_field().'
-            <input type="hidden" name="uid" value="'.$_GET['uid'].'">
+            <input type="hidden" name="uid" value="'.(int)($_GET['uid'] ?? 0).'">
             <input type="hidden" name="userid" value="'.$id.'">
             <button type="submit" class="medals-del" title="Delete all medals">
               <svg viewBox="0 0 24 24"><path d="M3 6h18M8 6V4h8v2m-1 0v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V6h10z"/></svg>

--- a/Admin/Templates/results_villages.tpl
+++ b/Admin/Templates/results_villages.tpl
@@ -60,10 +60,10 @@
 		<td>'.$delLink.'</td>
 	</tr>';
     }
-    echo '</table><div class="search-foot"><font>'.count($result).'</font> Villages Found "<font>'.$_POST['s'].'</font>"</div>';
+    echo '</table><div class="search-foot"><font>'.count($result).'</font> Villages Found "<font>'.e($_POST['s'] ?? '').'</font>"</div>';
 } else {
     echo '<tr><td colspan="5" class="no-res">No results</td></tr></table>';
-    echo '<div class="search-foot">No Villages Called "<font>'.$_POST['s'].'</font>"</div>';
+    echo '<div class="search-foot">No Villages Called "<font>'.e($_POST['s'] ?? '').'</font>"</div>';
 }
 ?>
 </div>

--- a/Admin/Templates/troopUpgrades.tpl
+++ b/Admin/Templates/troopUpgrades.tpl
@@ -58,7 +58,7 @@ $img = $tribe==1 ? "" : $tribe-1;
     <?php if($_SESSION['access']==ADMIN){ ?>
   <div class="upg-foot">
     <?php if($tribe==5){ echo '<span style="color:#94a3b8">Upgrades Troops</span>'; } else { echo '<a href="admin.php?p=addABTroops&did='.$_GET['did'].'">Upgrades Troops</a>'; } ?>
-    <a href="admin.php?p=techlog&did=<?=$_GET['did']?>" style="color:#64748b">Research Log</a>
+    <a href="admin.php?p=techlog&did=<?=(int)($_GET['did'] ?? 0)?>" style="color:#64748b">Research Log</a>
   </div>
   <?php if(isset($_GET['ab'])) echo '<div style="text-align:right;padding:0 8px 6px;color:#dc2626;font-weight:600;font-size:12px">AB Tech updated</div>'; ?>
     <?php } ?>

--- a/Admin/Templates/troops.tpl
+++ b/Admin/Templates/troops.tpl
@@ -52,7 +52,7 @@ $heroCount = $hero ? 1 : 0;
   </div>
   <?php if($_SESSION['access']==ADMIN){ ?>
   <div class="troops-foot">
-    <a href="admin.php?p=addTroops&did=<?=$_GET['did']?>"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>Edit Troops</a>
+    <a href="admin.php?p=addTroops&did=<?=(int)($_GET['did'] ?? 0)?>"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>Edit Troops</a>
     <?php if(isset($_GET['d'])) echo '<span style="color:#dc2626;font-weight:600">Troops edited</span>'; ?>
   </div>
   <?php } ?>

--- a/Admin/Templates/village.tpl
+++ b/Admin/Templates/village.tpl
@@ -120,7 +120,7 @@ if(isset($id)){
       <td style="text-align:right">
         <form action="../GameEngine/Admin/Mods/editVillageOwner.php" method="POST" style="display:flex;gap:4px;align-items:center;justify-content:flex-end">
           <?php echo csrf_field(); ?>
-          <input type="hidden" name="did" value="<?php echo $_GET['did']; ?>">
+          <input type="hidden" name="did" value="<?php echo (int)($_GET['did'] ?? 0); ?>">
           <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
           <input class="input-mini" type="text" name="newowner" value="<?php echo $user['id']; ?>" style="width:65px">
           <?php if($_SESSION['access'] == ADMIN) { ?>
@@ -132,7 +132,7 @@ if(isset($id)){
         <tr><td class="label">Name</td><td colspan="2">
           <form action="../GameEngine/Admin/Mods/renameVillage.php" method="POST" style="display:flex;gap:4px">
             <?php echo csrf_field(); ?>
-            <input type="hidden" name="did" value="<?php echo $_GET['did']; ?>">
+            <input type="hidden" name="did" value="<?php echo (int)($_GET['did'] ?? 0); ?>">
             <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
             <input class="input-mini" type="text" name="villagename" value="<?php echo $village['name']; ?>" style="flex:1">
             <?php if($_SESSION['access'] == ADMIN) { ?>
@@ -140,7 +140,7 @@ if(isset($id)){
 			<?php } ?>
           </form>
         </td></tr>
-        <tr><td class="label">Population</td><td colspan="2"><?php echo $village['pop'];?> <a href="admin.php?action=recountPop&did=<?php echo $_GET['did']; ?>" class="btn-icon" style="margin-left:4px"><?php echo $svgRefresh; ?></a></td></tr>
+        <tr><td class="label">Population</td><td colspan="2"><?php echo $village['pop'];?> <a href="admin.php?action=recountPop&did=<?php echo (int)($_GET['did'] ?? 0); ?>" class="btn-icon" style="margin-left:4px"><?php echo $svgRefresh; ?></a></td></tr>
         <tr><td class="label">Coords</td><td colspan="2"><a href="<?php echo HOMEPAGE ?>/karte.php?d=<?php echo $village['wref']; ?>&c=<?php echo $generator->getMapCheck($village['wref']); ?>" target="_blank" style="color:#16a34a;font-weight:600">(<?php echo $coor['x']."|".$coor['y']; ?>)</a></td></tr>
         <tr><td class="label">ID</td><td colspan="2"><?php echo $village['wref'];?></td></tr>
         <tr><td class="label">Field</td><td colspan="2" class="badge-field"><?php for ($i = 0; $i <= 3; $i++){ $a = $i + 1; echo $typ[$i].'x <img src="../img/admin/r/'.$a.'.gif">'.($i!=3?' | ':''); } ?></td></tr>
@@ -148,7 +148,7 @@ if(isset($id)){
     </div>
 <!-- 2. RESOURCES - FULL WIDTH -->
 <div class="vcard">
-  <div class="vhead">Resources<?php if($_SESSION['access'] == ADMIN) { ?><a href="admin.php?p=editResources&did=<?php echo $_GET['did']; ?>"><?php echo $svgEdit; ?></a><?php } ?>
+  <div class="vhead">Resources<?php if($_SESSION['access'] == ADMIN) { ?><a href="admin.php?p=editResources&did=<?php echo (int)($_GET['did'] ?? 0); ?>"><?php echo $svgEdit; ?></a><?php } ?>
 	</div>
   <table class="vtable" style="text-align:center">
     <tr style="background:#f8fafc;font-size:11px;color:#64748b"><td style="text-align:left">Res</td><td>Amt</td><td>Cap</td><td>Prod</td></tr>
@@ -185,7 +185,7 @@ if(isset($id)){
 <div class="vmap-wrap">
   <div class="map-card">
     <h3>Resource Fields</h3>
-    <a href="admin.php?p=editVillage&did=<?php echo $_GET['did']; ?>">
+    <a href="admin.php?p=editVillage&did=<?php echo (int)($_GET['did'] ?? 0); ?>">
       <div id="content" class="village1">
         <div id="village_map" class="f<?php echo $database->getVillageType($village['wref']); ?>">
           <?php for($f = 1; $f < 19; $f++){ $level = $fdata['f'.($f)]; echo "<img src=\"../img/x.gif\" class=\"reslevel rf".$f." level".$level."\">"; } ?>
@@ -226,7 +226,7 @@ if(isset($id)){
   </table>
 </div>
 
-<div style="text-align:center;margin:12px 0"><a href="admin.php?p=villagelog&did=<?php echo $_GET['did']; ?>" style="color:#2563eb;font-weight:500;font-size:13px">Village Build Log →</a></div>
+<div style="text-align:center;margin:12px 0"><a href="admin.php?p=villagelog&did=<?php echo (int)($_GET['did'] ?? 0); ?>" style="color:#2563eb;font-weight:500;font-size:13px">Village Build Log →</a></div>
 
 </div>
 <?php } else { include("404.tpl"); } } ?>


### PR DESCRIPTION
Part of #139 (reflected XSS, #3). Several admin templates echoed request
parameters straight into HTML attributes, JS strings and text nodes without
escaping, allowing reflected XSS (a crafted ?did=, ?uid=, ?aid=, ?msg= or
village search term could break out of the surrounding attribute).

Numeric IDs (did/uid/aid) are now cast to (int) on output; free-text values
(the ?msg= status line and the reflected village search term) go through the
e() HTML-escape helper. Covers addTroops, addABTroops, massmessage,
editAccess, troops, editVillage, troopUpgrades, allymedals, village,
editResources, playermedals and results_villages.

Tested in-game.