### PR TITLE
fix(admin): escape reflected filter param in report/msg templates [#139]

### DIFF
--- a/Admin/Templates/msg.tpl
+++ b/Admin/Templates/msg.tpl
@@ -128,7 +128,7 @@ $msgs = $database->query("SELECT * FROM ".TB_PREFIX."mdata WHERE $where ORDER BY
     </div>
     <form class="search-box" method="get">
       <input type="hidden" name="p" value="msg">
-      <input type="hidden" name="f" value="<?php echo $filter;?>">
+      <input type="hidden" name="f" value="<?php echo htmlspecialchars($filter);?>">
       <input type="text" name="q" placeholder="Search..." value="<?php echo htmlspecialchars($search);?>">
     </form>
   </div>
@@ -162,7 +162,7 @@ $msgs = $database->query("SELECT * FROM ".TB_PREFIX."mdata WHERE $where ORDER BY
   <?php if($total > $limit){ $pages = ceil($total/$limit);?>
   <div class="pagination">
     <?php for($p=1;$p<=$pages && $p<=15;$p++){?>
-      <a href="?p=msg&page=<?php echo $p;?>&f=<?php echo $filter;?>&q=<?php echo urlencode($search);?>" class="<?php echo $p==$page?'active':'';?>"><?php echo $p;?></a>
+      <a href="?p=msg&page=<?php echo $p;?>&f=<?php echo urlencode($filter);?>&q=<?php echo urlencode($search);?>" class="<?php echo $p==$page?'active':'';?>"><?php echo $p;?></a>
     <?php }?>
   </div>
   <?php }?>

--- a/Admin/Templates/report.tpl
+++ b/Admin/Templates/report.tpl
@@ -102,7 +102,7 @@ $typeNames = [1=>'reinforcement',2=>'attack',3=>'defence',4=>'scout',5=>'trade',
     </div>
     <form class="search-box" method="get">
       <input type="hidden" name="p" value="report">
-      <input type="hidden" name="f" value="<?php echo $filter;?>">
+      <input type="hidden" name="f" value="<?php echo htmlspecialchars($filter);?>">
       <input type="text" name="q" placeholder="Search..." value="<?php echo htmlspecialchars($search);?>">
     </form>
   </div>
@@ -134,7 +134,7 @@ $typeNames = [1=>'reinforcement',2=>'attack',3=>'defence',4=>'scout',5=>'trade',
   <?php if($total > $limit){ $pages = ceil($total/$limit);?>
   <div class="pagination">
     <?php for($p=1;$p<=$pages && $p<=15;$p++){?>
-      <a href="?p=report&page=<?php echo $p;?>&f=<?php echo $filter;?>&q=<?php echo urlencode($search);?>" class="<?php echo $p==$page?'active':'';?>"><?php echo $p;?></a>
+      <a href="?p=report&page=<?php echo $p;?>&f=<?php echo urlencode($filter);?>&q=<?php echo urlencode($search);?>" class="<?php echo $p==$page?'active':'';?>"><?php echo $p;?></a>
     <?php }?>
   </div>
   <?php }?>


### PR DESCRIPTION
Part of #139 (reflected XSS, #3). The admin report and message list pages
(report.tpl, msg.tpl) echoed the $_GET['f'] filter straight into a hidden
form value attribute and into the filter/pagination href without escaping,
allowing reflected XSS (a crafted ?f="><script>... could break out of the
attribute / href context).

The filter is now HTML-escaped in the hidden input value (htmlspecialchars)
and URL-encoded in the generated links (urlencode), matching how the adjacent
search term ($_GET['q']) is already handled. $bid/$nid/$page are already cast
to int and $search is escaped, so no other reflected sink remains on these
pages.

Tested in-game.