### PR TITLE
fix(admin): escape stored player values in admin templates [#139]

### DIFF
--- a/Admin/Templates/Newmessage.tpl
+++ b/Admin/Templates/Newmessage.tpl
@@ -50,7 +50,7 @@ $user = $database->getUserArray($id,1);
   <div class="msg-card">
     <div class="msg-head">
       <h4>New Message</h4>
-      <div>to <a href="admin.php?p=player&uid=<?php echo $user['id']; ?>"><?php echo $user['username']; ?></a></div>
+      <div>to <a href="admin.php?p=player&uid=<?php echo $user['id']; ?>"><?php echo htmlspecialchars($user['username']); ?></a></div>
     </div>
     
     <form method="post" action="../GameEngine/Admin/Mods/sendMessage.php" name="msg">
@@ -60,7 +60,7 @@ $user = $database->getUserArray($id,1);
         
         <div class="msg-row">
           <div class="msg-label">Recipient</div>
-          <div><strong style="color:#0f172a"><?php echo $user['username']; ?></strong> (UID <?php echo $id; ?>)</div>
+          <div><strong style="color:#0f172a"><?php echo htmlspecialchars($user['username']); ?></strong> (UID <?php echo $id; ?>)</div>
         </div>
         
         <div class="msg-row">

--- a/Admin/Templates/addABTroops.tpl
+++ b/Admin/Templates/addABTroops.tpl
@@ -58,7 +58,7 @@ if(isset($id)){
 <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 
 <div class="ab-card">
-  <div class="ab-head">Upgrades – <?php echo $village['name']; ?> (<?php echo $coor['x'].'|'.$coor['y']; ?>)</div>
+  <div class="ab-head">Upgrades – <?php echo htmlspecialchars($village['name']); ?> (<?php echo $coor['x'].'|'.$coor['y']; ?>)</div>
   
   <div class="ab-grid">
     <div class="ab-row header">

--- a/Admin/Templates/addTroops.tpl
+++ b/Admin/Templates/addTroops.tpl
@@ -60,7 +60,7 @@ if(isset($id)){
 <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
 
 <div class="addtroops-card">
-  <div class="addtroops-head">Edit troops – <?php echo $village['name']; ?> (<?php echo $coor['x'].'|'.$coor['y']; ?>)</div>
+  <div class="addtroops-head">Edit troops – <?php echo htmlspecialchars($village['name']); ?> (<?php echo $coor['x'].'|'.$coor['y']; ?>)</div>
   
   <div class="addtroops-grid">
   <?php for($i=1;$i<11;$i++){

--- a/Admin/Templates/editAccess.tpl
+++ b/Admin/Templates/editAccess.tpl
@@ -34,7 +34,7 @@ if(isset($_GET['uid']))
 		<table id="member" style="width:300px;">
 			<thead>
 				<tr>
-					<th colspan="2">Edit <?php echo $player['username']; ?>'s access</th>
+					<th colspan="2">Edit <?php echo htmlspecialchars($player['username']); ?>'s access</th>
 				</tr>
 				<tr>
 					<td></td>

--- a/Admin/Templates/editResources.tpl
+++ b/Admin/Templates/editResources.tpl
@@ -49,7 +49,7 @@ if($id){
 	<input type="hidden" name="did" id="did" value="<?php echo (int)($_GET['did'] ?? 0); ?>">
     
     <div class="res-card">
-      <div class="res-head">Modify Resources — <?php echo $village['name']; ?> (<?php echo $coor['x']; ?>|<?php echo $coor['y']; ?>)</div>
+      <div class="res-head">Modify Resources — <?php echo htmlspecialchars($village['name']); ?> (<?php echo $coor['x']; ?>|<?php echo $coor['y']; ?>)</div>
       
       <table class="res-table">
         <thead>

--- a/Admin/Templates/msg.tpl
+++ b/Admin/Templates/msg.tpl
@@ -41,14 +41,14 @@ if($nid > 0){
     <link href="../<?php echo GP_LOCATE;?>travian.css?e21d2" rel="stylesheet" type="text/css">
     <div style="max-width:900px;margin:20px auto">
       <a href="?p=msg" style="font-size:12px">← Back to messages</a>
-      <div style="margin:8px 0;font-size:12px"><span class="b">Sent to</span>: <?php echo $database->getUserField($msg[0]['target'],'username',0);?></div>
+      <div style="margin:8px 0;font-size:12px"><span class="b">Sent to</span>: <?php echo htmlspecialchars($database->getUserField($msg[0]['target'],'username',0));?></div>
       <div id="content" class="messages">
         <h1>Message</h1>
         <div id="read_head" class="msg_head"></div>
         <div id="read_content" class="msg_content">
           <img src="../img/x.gif" id="label" class="read" alt="">
           <div id="heading">
-            <div><?php echo $database->getUserField($msg[0]['owner'],'username',0);?></div>
+            <div><?php echo htmlspecialchars($database->getUserField($msg[0]['owner'],'username',0));?></div>
             <div><?php echo htmlspecialchars($msg[0]['topic']);?></div>
           </div>
           <div id="time">

--- a/Admin/Templates/natars.tpl
+++ b/Admin/Templates/natars.tpl
@@ -116,8 +116,8 @@ $deletedArtifacts = $database->getDeletedArtifacts();
           <td><?php echo $info['bonus'];?></td>
           <td><?php echo $info['effectInfluence'];?></td>
           <td><?php echo date("d.m.Y H:i:s", $artifact['conquered']);?></td>
-          <td><?php $u=$database->getUserField($artifact['owner'],"username",0); echo $u!="[?]"?'<a href="?p=player&uid='.$artifact['owner'].'">'.$u.'</a>':'<span style="color:gray">'.$u.'</span>';?></td>
-          <td><?php $v=$database->getVillageField($artifact['vref'],"name"); echo $v!="[?]"?'<a href="?p=village&did='.$artifact['vref'].'">'.$v.'</a>':'<span style="color:gray">'.$v.'</span>';?></td>
+          <td><?php $u=htmlspecialchars($database->getUserField($artifact['owner'],"username",0)); echo $u!="[?]"?'<a href="?p=player&uid='.$artifact['owner'].'">'.$u.'</a>':'<span style="color:gray">'.$u.'</span>';?></td>
+          <td><?php $v=htmlspecialchars($database->getVillageField($artifact['vref'],"name")); echo $v!="[?]"?'<a href="?p=village&did='.$artifact['vref'].'">'.$v.'</a>':'<span style="color:gray">'.$v.'</span>';?></td>
         </tr>
         <?php } }?>
       </table>

--- a/Admin/Templates/playeradditionalinfo.tpl
+++ b/Admin/Templates/playeradditionalinfo.tpl
@@ -64,11 +64,11 @@
 		</tr>
 		<tr>
 			<td>Sitter 1</td>
-			<td><?php echo $user['sit1'] >= 1 ? '<a href="admin.php?p=player&uid='.$user['sit1'].'">'.$database->getUserField($user['sit1'],"username",0).'</a>' : '<span style="color:#94a3b8">No Sitter</span>'; ?></td>
+			<td><?php echo $user['sit1'] >= 1 ? '<a href="admin.php?p=player&uid='.$user['sit1'].'">'.htmlspecialchars($database->getUserField($user['sit1'],"username",0)).'</a>' : '<span style="color:#94a3b8">No Sitter</span>'; ?></td>
 		</tr>
 		<tr>
 			<td>Sitter 2</td>
-			<td><?php echo $user['sit2'] >= 1 ? '<a href="admin.php?p=player&uid='.$user['sit2'].'">'.$database->getUserField($user['sit2'],"username",0).'</a>' : '<span style="color:#94a3b8">No Sitter</span>'; ?></td>
+			<td><?php echo $user['sit2'] >= 1 ? '<a href="admin.php?p=player&uid='.$user['sit2'].'">'.htmlspecialchars($database->getUserField($user['sit2'],"username",0)).'</a>' : '<span style="color:#94a3b8">No Sitter</span>'; ?></td>
 		</tr>
 		<tr>
 			<td>Beginners Protection</td>

--- a/Admin/Templates/playerdeletion.tpl
+++ b/Admin/Templates/playerdeletion.tpl
@@ -5,7 +5,7 @@
         <strong style="color:#e67e22;"><?php echo $delTime; ?></strong>
     </div>
     <a href="?p=player&uid=<?php echo $user['id']; ?>&action=StopDel" 
-       onclick="return confirm('Cancel deletion for <?php echo $user['username']; ?>?');"
+       onclick="return confirm('Cancel deletion for <?php echo htmlspecialchars(addslashes($user['username'])); ?>?');"
        title="Cancel deletion"
        style="background:#e74c3c; color:#fff; text-decoration:none; padding:6px 10px; border-radius:6px; font-weight:bold;">
        ✖ Cancel

--- a/Admin/Templates/playerheroinfo.tpl
+++ b/Admin/Templates/playerheroinfo.tpl
@@ -91,7 +91,7 @@ if ($hero !== false) {
 	<tr><td colspan="3" class="hero-sub" style="text-align:center">Hero #<?php echo $x++; ?></td></tr>
 	<tr>
 		<td width="35%">Hero Name</td> 
-		<td colspan="2" class="hero-name"><?php echo $h['name']; ?></td> 
+		<td colspan="2" class="hero-name"><?php echo htmlspecialchars($h['name']); ?></td>
 	</tr>
 	<tr>
 		<td>Hero Level</td> 

--- a/Admin/Templates/playerinfo.tpl
+++ b/Admin/Templates/playerinfo.tpl
@@ -48,7 +48,7 @@
 
     <thead>
         <tr>
-            <th colspan="2">Player <a href="admin.php?p=player&uid=<?php echo $user['id'];?>"><?php echo $user['username'];?></a></th>
+            <th colspan="2">Player <a href="admin.php?p=player&uid=<?php echo $user['id'];?>"><?php echo htmlspecialchars($user['username']);?></a></th>
         </tr>
         <tr>
             <td>Details</td>

--- a/Admin/Templates/village.tpl
+++ b/Admin/Templates/village.tpl
@@ -116,7 +116,7 @@ if(isset($id)){
 <div class="vcard">
   <div class="vhead">Village Information</div>
   <table class="vtable">
-    <tr><td class="label">Owner</td><td><a href="admin.php?p=player&uid=<?php echo $village['owner']; ?>" style="color:#2563eb;font-weight:600"><?php echo $user['username']; ?></a></td>
+    <tr><td class="label">Owner</td><td><a href="admin.php?p=player&uid=<?php echo $village['owner']; ?>" style="color:#2563eb;font-weight:600"><?php echo htmlspecialchars($user['username']); ?></a></td>
       <td style="text-align:right">
         <form action="../GameEngine/Admin/Mods/editVillageOwner.php" method="POST" style="display:flex;gap:4px;align-items:center;justify-content:flex-end">
           <?php echo csrf_field(); ?>
@@ -134,7 +134,7 @@ if(isset($id)){
             <?php echo csrf_field(); ?>
             <input type="hidden" name="did" value="<?php echo (int)($_GET['did'] ?? 0); ?>">
             <input type="hidden" name="admid" value="<?php echo $_SESSION['id']; ?>">
-            <input class="input-mini" type="text" name="villagename" value="<?php echo $village['name']; ?>" style="flex:1">
+            <input class="input-mini" type="text" name="villagename" value="<?php echo htmlspecialchars($village['name']); ?>" style="flex:1">
             <?php if($_SESSION['access'] == ADMIN) { ?>
 			<button class="btn-icon" title="Rename"><?php echo $svgEdit; ?></button>
 			<?php } ?>
@@ -164,7 +164,7 @@ if(isset($id)){
       <div class="vhead">Expansion</div>
       <table class="vtable" style="text-align:center">
         <tr style="background:#f8fafc;font-size:11px;color:#64748b"><td>Village</td><td>Pop</td><td>CP</td></tr>
-        <?php for($e = 1; $e < 4; $e++){ $exp = $village['exp'.$e.'']; if($exp == 0){ echo '<tr><td>-</td><td>-</td><td>-</td></tr>'; }else{ $vill = $database->getVillage($exp); echo '<tr><td><a href="admin.php?p=village&did='.$vill['wref'].'" style="color:#2563eb">'.$vill['name'].'</a></td><td>'.$vill['pop'].'</td><td>'.$vill['cp'].'</td></tr>'; } } ?>
+        <?php for($e = 1; $e < 4; $e++){ $exp = $village['exp'.$e.'']; if($exp == 0){ echo '<tr><td>-</td><td>-</td><td>-</td></tr>'; }else{ $vill = $database->getVillage($exp); echo '<tr><td><a href="admin.php?p=village&did='.$vill['wref'].'" style="color:#2563eb">'.htmlspecialchars($vill['name']).'</a></td><td>'.$vill['pop'].'</td><td>'.$vill['cp'].'</td></tr>'; } } ?>
       </table>
     </div>
 
@@ -195,7 +195,7 @@ if(isset($id)){
   </div>
   </br>
   <div class="map-card">
-    <h3>Village Center - <?php echo $village['name']; ?></h3>
+    <h3>Village Center - <?php echo htmlspecialchars($village['name']); ?></h3>
     <?php $WWLevel = $fdata['f99t']; $wallLevel = $fdata['f40t']; if($wallLevel == 0) $wallType = "d2_0"; else { switch($user['tribe']){ case 1: case 5: default: $wallType = "d2_11"; break; case 2: $wallType = "d2_12"; break; case 3: $wallType = "d2_1"; break; } } ?>
     <div id="content" class="village2">
       <div id="village_map" class="<?php echo $wallType; ?>">


### PR DESCRIPTION
Part of #139 (stored XSS, #2) — and the final lot, so this closes the issue.

  Closes #139

  Player-supplied values pulled from the DB (usernames, village names, hero
  names) were echoed unescaped in several admin templates, allowing stored XSS
  in the admin panel. Wrap them in htmlspecialchars() at the output point,
  matching the escaping already applied across the rest of the admin templates:

  - village.tpl: owner username, village name (rename input value), expansion
    village name, village-center heading
  - playerinfo.tpl / playerheroinfo.tpl / playeradditionalinfo.tpl: username,
    hero name, sitter usernames
  - editAccess.tpl / editResources.tpl / addTroops.tpl / addABTroops.tpl:
    username / village name in headings
  - Newmessage.tpl / msg.tpl: recipient and message-party usernames
  - natars.tpl: old owner username and old village name of deleted artifacts

  playerdeletion.tpl echoes the username inside a JS string in an onclick handler
  (double context), so it is escaped with addslashes() then htmlspecialchars() to
  neutralise both the JS-string and HTML-attribute breakout.

  These fields are stored raw (no escaping at write time), unlike profile
  descriptions which are escaped on write, so escaping at display is the correct
  layer here.

  Tested in-game.