### PR TITLE
fix(profile): store profile descriptions raw to stop double-escaping

### DIFF
--- a/GameEngine/Admin/Mods/editUser.php
+++ b/GameEngine/Admin/Mods/editUser.php
@@ -65,25 +65,21 @@ $email     = $database->escape($email);
 
 $tribe    = max(1, min(5, (int)($_POST['tribe'] ?? 1)));
 
+// BUG-3: store location/descriptions raw. escape() keeps the interpolated UPDATE
+// SQL-safe and strip_tags() drops markup; every display site (player.tpl,
+// playerinfo.tpl, editUser.tpl) escapes with htmlspecialchars(), so the extra
+// RemoveXSS() here only double-escaped the stored value (literal &quot; entities).
 $location_raw = trim($_POST['location'] ?? '');
-$location = $database->escape(
-    $database->RemoveXSS(mb_substr(strip_tags($location_raw), 0, 50))
-);
+$location = $database->escape(mb_substr(strip_tags($location_raw), 0, 50));
 
 $desc1_raw = $_POST['desc1'] ?? '';
-$desc1 = $database->escape(
-    $database->RemoveXSS(mb_substr(strip_tags($desc1_raw, '<b><i><u><br>'), 0, 5000))
-);
+$desc1 = $database->escape(mb_substr(strip_tags($desc1_raw, '<b><i><u><br>'), 0, 5000));
 
 $desc2_raw = $_POST['desc2'] ?? '';
-$desc2 = $database->escape(
-    $database->RemoveXSS(mb_substr(strip_tags($desc2_raw, '<b><i><u><br>'), 0, 5000))
-);
+$desc2 = $database->escape(mb_substr(strip_tags($desc2_raw, '<b><i><u><br>'), 0, 5000));
 
 $quest_raw = trim($_POST['quest'] ?? '');
-$quest = $database->escape(
-    $database->RemoveXSS(mb_substr(strip_tags($quest_raw), 0, 200))
-);
+$quest = $database->escape(mb_substr(strip_tags($quest_raw), 0, 200));
 
 // ---------------------------------------------------------------------------
 // Update

--- a/GameEngine/Profile.php
+++ b/GameEngine/Profile.php
@@ -219,9 +219,13 @@ class Profile {
     $birthday = preg_match('/^\d{4}-\d{1,2}-\d{1,2}$/', $birthday) ? $birthday : '0';
 
     $mw   = (int)($post['mw'] ?? 0);
-	$ort = $database->RemoveXSS(trim($post['ort'] ?? ''));
-	$be1 = $database->RemoveXSS(trim($post['be1'] ?? '')); // right description
-	$be2 = $database->RemoveXSS(trim($post['be2'] ?? '')); // left description
+	// BUG-3: store the location/descriptions raw. submitProfile() uses a prepared
+	// statement (SQL-safe) and every display site escapes with htmlspecialchars()
+	// before rendering BBCode, so RemoveXSS() here only double-escaped the data
+	// (baked-in backslashes from its SQL escape + literal &quot; entities).
+	$ort = trim($post['ort'] ?? '');
+	$be1 = trim($post['be1'] ?? ''); // right description
+	$be2 = trim($post['be2'] ?? ''); // left description
 
     $database->submitProfile($session->uid, $mw, $ort, $birthday, $be2, $be1);
 


### PR DESCRIPTION
  The player profile editor (`Profile::updateProfile`) and the admin `editUser`
  Mod ran the location and right/left descriptions through `Database::RemoveXSS()`
  before storing them. `RemoveXSS()` both SQL-escapes (`mysqli_real_escape_string`)
  and HTML-escapes (`htmlspecialchars`) its input, which corrupted the stored data:

  - `Profile::updateProfile` stores via `submitProfile()`'s prepared statement, so
    `RemoveXSS()`'s SQL escaping was baked into the database as literal backslashes
    (e.g. `\&quot;`), on top of the HTML entities.
  - Every display site (`Templates/Profile/profile.tpl`, `overview.tpl`,
    `Admin/Templates/player.tpl`, `playerinfo.tpl`, `editUser.tpl`) already escapes
    these fields with `htmlspecialchars(ENT_QUOTES)` before rendering BBCode, so the
    write-time `htmlspecialchars()` produced double-encoded output (visible `&quot;`).

  Store the values raw instead: rely on the prepared statement / `escape()` for SQL
  safety and on the existing display-time `htmlspecialchars()` for XSS safety. This
  matches the "store raw, escape at display" convention used elsewhere. `RemoveXSS()`
  is left untouched; its remaining callers (alliance name/tag, gpack URL) feed
  string-interpolated queries where its SQL escaping is still required.