### PR TITLE
Refactor(Units): collapse the duplicated procUnits() cases 1-4 [#219]

### DIFF
--- a/GameEngine/Units.php
+++ b/GameEngine/Units.php
@@ -24,32 +24,8 @@ class Units {
 
             switch($post['c']) {
                 case 1:
-                    if (isset($post['a']) && $post['a'] == 533374 && empty($post['disabled'])) $this->sendTroops($post);
-                	else
-                	{	
-                        $post = $this->loadUnits($post);
-                        return $post;
-                    }
-                    break;
-                    
                 case 2:
-                    if (isset($post['a']) && $post['a'] == 533374 && empty($post['disabled'])) $this->sendTroops($post);
-                    else
-                    {
-                        $post = $this->loadUnits($post);
-                        return $post;
-                    }
-                    break;
-         
                 case 3:
-                    if (isset($post['a']) && $post['a'] == 533374 && empty($post['disabled'])) $this->sendTroops($post);
-                    else
-                    {
-                        $post = $this->loadUnits($post);
-                        return $post;
-                    }
-                    break;
-                    
                 case 4:
                     if (isset($post['a']) && $post['a'] == 533374 && empty($post['disabled'])) $this->sendTroops($post);
                     else
@@ -58,7 +34,7 @@ class Units {
                         return $post;
                     }
                     break;
-                    
+
                 case 5:
                     if (isset($post['a']) && $post['a'] == "new") $this->Settlers($post);
                     else


### PR DESCRIPTION
Phase-1 item of the #219 roadmap, behaviour-preserving.

Cases 1 to 4 of the `procUnits()` switch had a byte-identical body: send troops
when the rally-point form is submitted (`a == 533374` and not disabled),
otherwise load the unit form and return. Stack the four `case` labels and keep a
single shared body via switch fall-through. No behaviour change.

Lint clean, in-game tested (reinforcement / normal attack / raid sent from the
rally point: confirmation screen + actual dispatch, plus the error path back to
a2b.php).