### PR TITLE
Refactor(Technology): make getTrainingList() table-driven [#219]

### DIFF
--- a/GameEngine/Technology.php
+++ b/GameEngine/Technology.php
@@ -121,42 +121,24 @@ class Technology {
 		$residence = [9, 10, 19, 20, 29, 30, 49, 50];
 		$trapper = [99];
 		
-		if(count($trainingarray) > 0) {
+		$categories = [
+			1 => [$barracks, 0, null],
+			2 => [$stables, 0, null],
+			3 => [$workshop, 0, null],
+			4 => [$residence, 0, null],
+			5 => [$greatbarracks, 60, null],
+			6 => [$greatstables, 60, null],
+			7 => [$greatworkshop, 60, null],
+			8 => [$trapper, 0, 'Trap'],
+		];
+		
+		if(count($trainingarray) > 0 && isset($categories[$type])) {
+			[$units, $offset, $fallback] = $categories[$type];
 			foreach($trainingarray as $train) {
-				if($type == 1 && in_array($train['unit'],$barracks)) {
-				$train['name'] = $this->unarray[$train['unit']];
-				array_push($listarray,$train);
-				}
-				if($type == 2 && in_array($train['unit'],$stables)) {
-					$train['name'] = $this->unarray[$train['unit']];
-					array_push($listarray,$train);
-				}
-				if($type == 3 && in_array($train['unit'],$workshop)) {
-					$train['name'] = $this->unarray[$train['unit']];
-					array_push($listarray,$train);
-				}
-				if($type == 4 && in_array($train['unit'],$residence)) {
-					$train['name'] = $this->unarray[$train['unit']];
-					array_push($listarray,$train);
-				}
-				if($type == 5 && in_array($train['unit'],$greatbarracks)) {
-					$train['name'] = $this->unarray[$train['unit']-60];
-					$train['unit'] -= 60;
-					array_push($listarray,$train);
-				}
-				if($type == 6 && in_array($train['unit'],$greatstables)) {
-					$train['name'] = $this->unarray[$train['unit']-60];
-					$train['unit'] -= 60;
-					array_push($listarray,$train);
-				}
-				if($type == 7 && in_array($train['unit'],$greatworkshop)) {
-					$train['name'] = $this->unarray[$train['unit']-60];
-					$train['unit'] -= 60;
-					array_push($listarray,$train);
-				}
-				if($type == 8 && in_array($train['unit'],$trapper)) {
-					$train['name'] = $this->unarray[$train['unit']]?? 'Trap';
-					array_push($listarray,$train);
+				if(in_array($train['unit'], $units)) {
+					$train['unit'] -= $offset;
+					$train['name'] = $fallback === null ? $this->unarray[$train['unit']] : ($this->unarray[$train['unit']] ?? $fallback);
+					array_push($listarray, $train);
 				}
 			}
 		}


### PR DESCRIPTION
Phase-1 item of the #219 roadmap, behaviour-preserving.

`getTrainingList()` repeated eight near-identical `if`-blocks, one per training
building category, each filtering the in-training units and (for the three
"great" buildings) subtracting 60 from the unit id. Replace them with a
`$categories` table mapping `$type => [units, offset, fallback]` and a single
loop.

Behaviour-preserving: offset 0 leaves the unit id untouched (types 1-4, 8);
offset 60 decrements it then reads the name from the decremented id (types 5-7),
identical to the old "name from unit-60, then unit -= 60". The `'Trap'` fallback
is applied only for the trapper (type 8); the other types keep the direct
`unarray` access (same missing-key semantics as before).

Lint clean, in-game tested (barracks / stable / workshop / residence training
lists, the great buildings, and the trapper).