### PR TITLE
fix(admin): render a proper error page instead of a blank page on denial [#299]

### DIFF
--- a/GameEngine/Admin/Mods/addABTroops.php
+++ b/GameEngine/Admin/Mods/addABTroops.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/Mods/addTroops.php
+++ b/GameEngine/Admin/Mods/addTroops.php
@@ -12,11 +12,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die(defined('ACCESS_DENIED_ADMIN') ? ACCESS_DENIED_ADMIN : 'Access Denied: You are not Admin!');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/Mods/addUsers.php
+++ b/GameEngine/Admin/Mods/addUsers.php
@@ -28,12 +28,14 @@ include_once($autoprefix."GameEngine/Database.php");
 
 // Admin-rank guard (defense-in-depth). Reaching any file under /Admin already
 // requires an admin session: Session.php's checkLogin() gates the whole /Admin
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 // path on $_SESSION['admin_username'], so a plain player session is bounced to
 // login.php before this point. This re-check aligns addUsers with its sibling
 // Mods (gold.php, cp.php, editResources.php, ...), which all assert the rank
 // here too; it is a redundant safety net, not the sole guard.
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/Mods/additional.php
+++ b/GameEngine/Admin/Mods/additional.php
@@ -18,8 +18,10 @@
 include_once("../../config.php");
 include_once("../../Database.php");
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) session_start();
-if(($_SESSION['access']?? 0) < ADMIN) die("Access Denied: You are not Admin!");
+if(($_SESSION['access']?? 0) < ADMIN) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
 // itself (it does not go through admin.php's central csrf_verify()).

--- a/GameEngine/Admin/Mods/cp.php
+++ b/GameEngine/Admin/Mods/cp.php
@@ -8,8 +8,10 @@
 ##  Copyright:     TravianZ (c) 2010-2025. All rights reserved.                ##
 ##                                                                             ##
 #################################################################################
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) session_start();
-if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
+if($_SESSION['access'] < 9) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
 // itself (it does not go through admin.php's central csrf_verify()).
@@ -37,7 +39,7 @@ $sql = mysqli_query($GLOBALS["link"], "SELECT * FROM ".TB_PREFIX."users WHERE id
 $access = mysqli_fetch_array($sql);
 $sessionaccess = $access['access'];
 
-if($sessionaccess != 9) die("<h1><font color=\"red\">Access Denied: You are not Admin!</font></h1>");
+if($sessionaccess != 9) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 mysqli_query($GLOBALS["link"], "UPDATE ".TB_PREFIX."users SET cp = cp + ".(int) $_POST['cp']." WHERE id = ".$id."");
 

--- a/GameEngine/Admin/Mods/delAli.php
+++ b/GameEngine/Admin/Mods/delAli.php
@@ -9,9 +9,11 @@
 ##  Copyright:     TravianZ (c) 2010-2025. All rights reserved.                 ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) { session_start(); }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -47,7 +49,7 @@ if ($aid <= 0 || $admid <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($admid, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/delUser.php
+++ b/GameEngine/Admin/Mods/delUser.php
@@ -9,9 +9,11 @@
 ##  Copyright:     TravianZ (c) 2010-2025. All rights reserved.                 ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) { session_start(); }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -48,7 +50,7 @@ if ($uid <= 0 || $admid <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($admid, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 if (!password_verify($pass, $admin['password'])) {
     die('<script>alert("Parola admin gresita!");history.back();</script>');

--- a/GameEngine/Admin/Mods/delallymedal.php
+++ b/GameEngine/Admin/Mods/delallymedal.php
@@ -9,11 +9,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -52,7 +54,7 @@ if ($delete <= 0 || $aid <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/delallymedalbyaid.php
+++ b/GameEngine/Admin/Mods/delallymedalbyaid.php
@@ -9,11 +9,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -51,7 +53,7 @@ if ($aid <= 0 || $session <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/delallymedalbyweek.php
+++ b/GameEngine/Admin/Mods/delallymedalbyweek.php
@@ -9,11 +9,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -51,7 +53,7 @@ if ($deleteweek <= 0 || $session <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/deletemedalbyweek.php
+++ b/GameEngine/Admin/Mods/deletemedalbyweek.php
@@ -9,11 +9,13 @@
 ##                                                                             ##
 ##################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -51,7 +53,7 @@ if ($deleteweek <= 0 || $session <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editAccess.php
+++ b/GameEngine/Admin/Mods/editAccess.php
@@ -8,8 +8,10 @@
 ##  Copyright:     TravianZ (c) 2010-2025. All rights reserved.                ##
 ##                                                                             ##
 #################################################################################
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) session_start();
-if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
+if($_SESSION['access'] < 9) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
 // itself (it does not go through admin.php's central csrf_verify()).
@@ -37,7 +39,7 @@ $sql = mysqli_query($GLOBALS["link"], "SELECT * FROM ".TB_PREFIX."users WHERE id
 $access = mysqli_fetch_array($sql);
 $sessionaccess = $access['access'];
 
-if($sessionaccess != 9) die("<h1><font color=\"red\">Access Denied: You are not Admin!</font></h1>");
+if($sessionaccess != 9) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 // Cast + whitelist the access level. $_POST['access'] was injected raw into
 // the UPDATE below (SQL injection). Only accept the values the admin form

--- a/GameEngine/Admin/Mods/editAli.php
+++ b/GameEngine/Admin/Mods/editAli.php
@@ -9,11 +9,13 @@
 ##  Copyright:     TravianZ (c) 2010-2025. All rights reserved.                 ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -51,7 +53,7 @@ if ($aid <= 0 || $admid <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($admid, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editBuildings.php
+++ b/GameEngine/Admin/Mods/editBuildings.php
@@ -11,11 +11,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/Mods/editHero.php
+++ b/GameEngine/Admin/Mods/editHero.php
@@ -11,11 +11,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/Mods/editOverall.php
+++ b/GameEngine/Admin/Mods/editOverall.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -55,7 +57,7 @@ if ($id <= 0 || $session <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editPassword.php
+++ b/GameEngine/Admin/Mods/editPassword.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -54,7 +56,7 @@ if ($id <= 0 || $session <= 0 || $newpw === '') {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editPlus.php
+++ b/GameEngine/Admin/Mods/editPlus.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/Mods/editProtection.php
+++ b/GameEngine/Admin/Mods/editProtection.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -54,7 +56,7 @@ if ($id <= 0 || $session <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editResources.php
+++ b/GameEngine/Admin/Mods/editResources.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -53,7 +55,7 @@ if ($id <= 0 || $session <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editSitter.php
+++ b/GameEngine/Admin/Mods/editSitter.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -55,7 +57,7 @@ if ($id <= 0 || $session <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editUser.php
+++ b/GameEngine/Admin/Mods/editUser.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -53,7 +55,7 @@ if ($id <= 0 || $session <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editUsername.php
+++ b/GameEngine/Admin/Mods/editUsername.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -54,7 +56,7 @@ if ($uid <= 0 || $session <= 0 || $username === '') {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editVillageOwner.php
+++ b/GameEngine/Admin/Mods/editVillageOwner.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -54,7 +56,7 @@ if ($did <= 0 || $session <= 0 || $newowner <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/editWeek.php
+++ b/GameEngine/Admin/Mods/editWeek.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -53,7 +55,7 @@ if ($id <= 0 || $session <= 0) {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/givePlus.php
+++ b/GameEngine/Admin/Mods/givePlus.php
@@ -11,11 +11,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/Mods/givePlusRes.php
+++ b/GameEngine/Admin/Mods/givePlusRes.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -43,7 +45,7 @@ include_once($autoprefix . "GameEngine/Database.php");
 $session = (int)($_POST['admid'] ?? 0);
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 $wood = (int)($_POST['wood'] ?? 0) * 86400;

--- a/GameEngine/Admin/Mods/giveResBonus.php
+++ b/GameEngine/Admin/Mods/giveResBonus.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -43,7 +45,7 @@ include_once($autoprefix . "GameEngine/Database.php");
 $session = (int)($_POST['admid'] ?? 0);
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/gold.php
+++ b/GameEngine/Admin/Mods/gold.php
@@ -10,8 +10,10 @@
 ##  Copyright:     TravianZ (c) 2010-2025. All rights reserved.                ##
 ##                                                                             ##
 #################################################################################
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) session_start();
-if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
+if($_SESSION['access'] < 9) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
 // itself (it does not go through admin.php's central csrf_verify()).
@@ -41,7 +43,7 @@ if($amount == 0){
 // verificare admin
 $check = mysqli_query($GLOBALS["link"], "SELECT access, username FROM ".TB_PREFIX."users WHERE id = $admid");
 $acc = mysqli_fetch_assoc($check);
-if(!$acc || $acc['access'] != 9) die("<h1><font color=\"red\">Access Denied</font></h1>");
+if(!$acc || $acc['access'] != 9) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 // 1. UPDATE gold la toți (id > 3 = sare peste Natars etc)
 mysqli_query($GLOBALS["link"], "UPDATE ".TB_PREFIX."users SET gold = gold + $amount WHERE id > 3") or die(mysqli_error($GLOBALS["link"]));

--- a/GameEngine/Admin/Mods/gold_1.php
+++ b/GameEngine/Admin/Mods/gold_1.php
@@ -12,8 +12,10 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) session_start();
-if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
+if($_SESSION['access'] < 9) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
 // itself (it does not go through admin.php's central csrf_verify()).
@@ -35,7 +37,7 @@ if($id <= 0 || $amount == 0){
 // verificare admin
 $check = mysqli_query($GLOBALS["link"], "SELECT access, username FROM ".TB_PREFIX."users WHERE id = $admid");
 $acc = mysqli_fetch_assoc($check);
-if(!$acc || $acc['access'] != 9) die("<h1><font color=\"red\">Access Denied</font></h1>");
+if(!$acc || $acc['access'] != 9) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 // 1. UPDATE GOLD
 mysqli_query($GLOBALS["link"], "UPDATE ".TB_PREFIX."users SET gold = gold + $amount WHERE id = $id") or die(mysqli_error($GLOBALS["link"]));

--- a/GameEngine/Admin/Mods/mainteneceBan.php
+++ b/GameEngine/Admin/Mods/mainteneceBan.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -43,7 +45,7 @@ include_once($autoprefix . "GameEngine/Database.php");
 $session = (int)($_POST['admid'] ?? 0);
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceCleanBanData.php
+++ b/GameEngine/Admin/Mods/mainteneceCleanBanData.php
@@ -9,11 +9,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -42,7 +44,7 @@ include_once($autoprefix . "GameEngine/Database.php");
 $session = (int)($_POST['admid'] ?? 0);
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceResetGold.php
+++ b/GameEngine/Admin/Mods/mainteneceResetGold.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -43,7 +45,7 @@ include_once($autoprefix . "GameEngine/Database.php");
 $session = (int)($_POST['admid'] ?? 0);
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceResetPlus.php
+++ b/GameEngine/Admin/Mods/mainteneceResetPlus.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -43,7 +45,7 @@ include_once($autoprefix . "GameEngine/Database.php");
 $session = (int)($_POST['admid'] ?? 0);
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceResetPlusBonus.php
+++ b/GameEngine/Admin/Mods/mainteneceResetPlusBonus.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -43,7 +45,7 @@ include_once($autoprefix . "GameEngine/Database.php");
 $session = (int)($_POST['admid'] ?? 0);
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/mainteneceUnban.php
+++ b/GameEngine/Admin/Mods/mainteneceUnban.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -43,7 +45,7 @@ include_once($autoprefix . "GameEngine/Database.php");
 $session = (int)($_POST['admid'] ?? 0);
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/massmessage.php
+++ b/GameEngine/Admin/Mods/massmessage.php
@@ -11,13 +11,15 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 session_start();
 
 include_once("../../config.php");
 include_once("../../Database.php");
 
 if (!isset($_SESSION['access']) || $_SESSION['access'] < ADMIN) {
-    die("Access Denied");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/Mods/medals.php
+++ b/GameEngine/Admin/Mods/medals.php
@@ -9,8 +9,10 @@
 ##  Copyright:     TravianZ (c) 2010-2025. All rights reserved.                ##
 ##                                                                             ##
 #################################################################################
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) session_start();
-if($_SESSION['access'] < 9) die("Access Denied: You are not Admin!");
+if($_SESSION['access'] < 9) admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
 // itself (it does not go through admin.php's central csrf_verify()).

--- a/GameEngine/Admin/Mods/recalcWH.php
+++ b/GameEngine/Admin/Mods/recalcWH.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -45,7 +47,7 @@ $id = (int)($_POST['id'] ?? 0);
 
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 if ($id <= 0) {

--- a/GameEngine/Admin/Mods/renameVillage.php
+++ b/GameEngine/Admin/Mods/renameVillage.php
@@ -10,11 +10,13 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token
@@ -54,7 +56,7 @@ if ($did <= 0 || $nameOrig === '') {
 // ---------------------------------------------------------------------------
 $admin = $database->getUserArray($session, 1);
 if (!$admin || (int)$admin['access'] !== 9) {
-    die('<h1><font color="red">Access Denied: You are not Admin!</font></h1>');
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // ---------------------------------------------------------------------------

--- a/GameEngine/Admin/Mods/sendMessage.php
+++ b/GameEngine/Admin/Mods/sendMessage.php
@@ -10,12 +10,14 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 if (!isset($_SESSION)) {
     session_start();
 }
 
 if (empty($_SESSION['access']) || $_SESSION['access'] < 9) {
-    die("Access Denied: You are not Admin!");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/Mods/sysmessage.php
+++ b/GameEngine/Admin/Mods/sysmessage.php
@@ -15,13 +15,15 @@
 ##                                                                             ##
 #################################################################################
 
+// #299: load CSRF helpers + admin_deny() before the access check below.
+require_once(__DIR__ . '/../csrf.php');
 session_start();
 
 include_once("../../config.php");
 include_once("../../Database.php");
 
 if (!isset($_SESSION['access']) || $_SESSION['access'] < ADMIN) {
-    die("Access Denied");
+    admin_deny('You must be signed in as an administrator to view this page. Your session may have expired — please return to the admin panel and sign in again.');
 }
 
 // Issue #139: this Mod is POSTed to directly, so it must verify the CSRF token

--- a/GameEngine/Admin/csrf.php
+++ b/GameEngine/Admin/csrf.php
@@ -41,6 +41,49 @@ if (!function_exists('csrf_token')) {
     }
 
     /**
+     * Render a clean, self-contained error page and stop execution (issue #299).
+     *
+     * The admin Mods are POSTed to directly; when the admin session is missing
+     * (e.g. it was destroyed by a game logout that shares the same PHP session,
+     * or the form was served from a mobile cache with a stale/empty token) the
+     * old code stopped with a bare die('<h1>Access Denied</h1>') fragment, which
+     * shows up as an essentially blank page. This renders a proper, styled error
+     * with a way back into the panel instead.
+     */
+    function admin_deny(string $message, string $title = 'Access Denied', int $httpCode = 403): void
+    {
+        if (!headers_sent()) {
+            http_response_code($httpCode);
+            header('Content-Type: text/html; charset=UTF-8');
+            // Never let this error page be cached (it is session-dependent).
+            header('Cache-Control: no-store, no-cache, must-revalidate');
+        }
+
+        $safeTitle = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+        $safeMsg   = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+
+        echo '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">'
+           . '<meta name="viewport" content="width=device-width, initial-scale=1">'
+           . '<title>' . $safeTitle . '</title><style>'
+           . 'body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;'
+           . 'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;'
+           . 'background:#0f172a;color:#e2e8f0}'
+           . '.card{background:#1e293b;border:1px solid #334155;border-radius:12px;padding:32px 28px;'
+           . 'max-width:420px;width:calc(100% - 32px);text-align:center;box-shadow:0 10px 30px rgba(0,0,0,.4)}'
+           . '.card h1{margin:0 0 10px;font-size:20px;color:#f87171}'
+           . '.card p{margin:0 0 22px;font-size:14px;line-height:1.55;color:#cbd5e1}'
+           . '.card a{display:inline-block;background:#2563eb;color:#fff;text-decoration:none;'
+           . 'padding:10px 18px;border-radius:8px;font-size:14px;font-weight:500}'
+           . '.card a:hover{background:#1d4ed8}'
+           . '</style></head><body><div class="card">'
+           . '<h1>' . $safeTitle . '</h1>'
+           . '<p>' . $safeMsg . '</p>'
+           . '<a href="/Admin/admin.php">Return to Admin Panel</a>'
+           . '</div></body></html>';
+        exit;
+    }
+
+    /**
      * Verify the CSRF token of a POST request.
      * Stops execution with HTTP 403 if the token is missing or does not match.
      * Uses hash_equals() instead of === to prevent timing attacks.
@@ -51,9 +94,13 @@ if (!function_exists('csrf_token')) {
         $stored    = csrf_token();
 
         if ($stored === '' || !hash_equals($stored, $submitted)) {
-            http_response_code(403);
             // Generic message — does not reveal details about the mechanism.
-            die('<h1>403 Forbidden</h1><p>Invalid or missing security token. Please go back and try again.</p>');
+            admin_deny(
+                'Your session may have expired or this page was loaded from cache. '
+                . 'Please reload the admin panel and try again.',
+                'Security Check Failed',
+                403
+            );
         }
     }
 }


### PR DESCRIPTION
Fixes #299.

**Root cause.** The admin panel and the game share the same PHP session
(`PHPSESSID`). `Session::Logout()` calls `session_destroy()`, which wipes the
shared session — including the admin's `access` and `_csrf_token`. On a mobile
browser the session cookie may also be dropped (SameSite) or a cached form
submitted with a stale/empty token. When that happens, an admin Mod (eg
`editBuildings.php`) stopped on a bare `die('<h1>Access Denied</h1>')` — or the
`die()` in `csrf_verify()` — which renders as an essentially blank page outside
the panel.

**Fix (the presentation issue raised in #299 — "we must receive an error not a
blank page").**
- Add a shared `admin_deny($message, $title, $httpCode)` helper in
  `GameEngine/Admin/csrf.php`: it renders a clean, self-contained, mobile-
  friendly styled error page (with a "Return to Admin Panel" link and a
  `no-store` header), then exits.
- `csrf_verify()` now uses it (clear "session expired / loaded from cache,
  please reload" message).
- Replace every bare `Access Denied` `die()` across the 42 admin Mods (both the
  session check and the DB re-check) with `admin_deny()`. Each Mod now loads
  `csrf.php` at the top so the helper is available before its first access
  check. Non-access `die()` calls (e.g. the admin-password check in `delUser`)
  are left untouched.

**Not covered here (follow-up):** the deeper root cause — admin and game
sharing one PHP session — should be fixed by giving the admin panel its own
session cookie name (`session_name()`), so a game logout can never destroy the
admin session. Optionally also send `no-store` on `admin.php` and relax the
admin cookie from `SameSite=Strict` to `Lax`.

> ⚠️ **I have not tested this in-game.** Since #299 only reproduces on your
> production setup (the mobile / shared-session trigger), **@Shadowss please
> test this in-game before merging** — I can't reproduce it locally. Lint is
> clean on all 43 files and the error page renders