### PR TITLE
fix(spawn): stop WW/artifact villages colliding on axis tiles [#301]

### DIFF
--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -1416,11 +1416,23 @@ class MYSQLi_DB implements IDbConnection {
                     break;
             }
 
+            // The four sectors must be mutually exclusive: any tile sitting on an
+            // axis (x = 0 or y = 0) used to satisfy two of the predicates below
+            // (e.g. "x <= 0" and "x >= 0" both matched x = 0). When a batch was
+            // spread over several sectors (WW villages, artifact villages),
+            // occupied = 0 was only flipped at the very end by setFieldTaken(),
+            // so two sectors could each pick the SAME axis tile and assign its
+            // wref to two villages. The duplicate addVillage() insert then hit
+            // the vdata PRIMARY KEY(wref) and aborted generateVillages() before
+            // setFieldTaken() ran, leaving the villages in vdata (visible in the
+            // Natars profile) but never marked on the map (issue #301). Using
+            // strict bounds on one side of each axis partitions the plane so a
+            // tile belongs to exactly one sector.
             switch($sector){
-                case 1: $newSector = "x <= 0 AND y >= 0"; break; // - | +       
-                case 2: $newSector = "x >= 0 AND y >= 0"; break; // + | +                   
-                case 3: $newSector = "x <= 0 AND y <= 0"; break; // - | -            
-                default: $newSector = "x >= 0 AND y <= 0"; // + | -                 
+                case 1: $newSector = "x < 0 AND y >= 0"; break; // - | +
+                case 2: $newSector = "x >= 0 AND y > 0"; break; // + | +
+                case 3: $newSector = "x <= 0 AND y < 0"; break; // - | -
+                default: $newSector = "x > 0 AND y <= 0"; // + | -
             }
 
             //Choose villages beetween two circumferences, by using their formula (x^2 + y^2 = r^2)


### PR DESCRIPTION
Fixes #301 — WW villages were listed under the Natars profile but never appeared on the map (their tiles showed as "Abandoned valley").

### Root cause
`Database::generateBase()`'s four sector predicates overlapped on the axes: a tile with `x = 0` or `y = 0` satisfied two of them (e.g. both `x <= 0` and `x >= 0` match `x = 0`). `createWWVillages()` and `addArtifactVillages()` generate a whole batch at once and only flip `occupied = 0 -> 1` at the very end (`setFieldTaken()`), so two sectors could each pick the **same** axis tile and assign its `wref` to two villages. The duplicate `addVillage()` insert then violated `vdata PRIMARY KEY(wref)`; under the PHP 8.1+ mysqli exception mode this threw and aborted `generateVillages()` before `setFieldTaken()` / `addResourceFields()` / `addUnits()` ran. Result: the villages existed in `vdata` (and showed up in the Natars profile) but their map tile was never marked occupied and had no resource fields or troops. `areWWVillagesSpawned()` only checks for one `natar = 1` row, so the tick never retried.

The reported broken tile `(0|-46)` sits exactly on the `x = 0` axis, which matches this.

### Fix
Make the four sectors mutually exclusive by using a strict bound on one side of each axis, so every tile belongs to exactly one sector and no `wref` can be handed out twice within a batch. One line per `case`. Covers artifact villages too (same code path).

### Testing
⚠️ **Not tested in-game on my side — @Shadowss & @zmn28hgbn59kcmlpio8unfh7fdre523esd28q9a, please test before merging.** Suggested check: force a WW spawn (admin Mod `addWWVillages`) and confirm the tiles become `occupied` / visible on the map, including a tile on an axis. The "Natars banner not T3.6" point from the issue is a separate cosmetic (gpack) matter and is **not** addressed here.