### PR TITLE
fix(combat): bounce attacks home when their target village no longer exists [#298]

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -2967,18 +2967,6 @@ class Automation {
 
             // calculate battles
             foreach($dataarray as $data) {
-                // If an earlier attack in this same batch razed the target village,
-                // its still-in-flight follow-up waves were already bounced straight
-                // home by DelVillage() (issue #298). Re-resolving them here would
-                // fight a now-deleted (phantom) village: getMInfo() returns NULL
-                // vdata columns, so the return trip is computed from a NULL wref
-                // (NULL coordinates) — yielding a bogus arrival time that strands
-                // the troops — and would also duplicate the bounce. Skip them.
-                if (isset($razedTargets[$data['to']])) {
-                    $data_num++;
-                    continue;
-                }
-
                 //set base things
 				$totaltraped_att = 0;
 				for($i = 1; $i <= 11; $i++) ${'traped'.$i} = 0;
@@ -3029,6 +3017,29 @@ class Automation {
                     $wallid       = $vt['wallid'];
                     $tblevel      = $vt['tblevel'];
                     $stonemason   = $vt['stonemason'];
+
+                    // Issue #298: the target village no longer exists — it was razed
+                    // either earlier in this same batch ($razedTargets), or in an
+                    // earlier tick whose still-in-flight follow-up waves DelVillage()
+                    // failed to bounce. getMInfo() then returns NULL vdata columns
+                    // ($to['wref'] is NULL), so resolving a battle here would fight a
+                    // phantom village and compute the return trip from NULL coordinates
+                    // — a bogus arrival time that strands the troops in an endless loop
+                    // (report against "[?]"). Bounce the whole army straight home
+                    // instead, exactly like DelVillage() does for in-flight attacks,
+                    // and mark the movement processed so it stops being re-fetched.
+                    if (isset($razedTargets[$data['to']]) || empty($to['wref'])) {
+                        // only own the bounce if DelVillage() hasn't already handled it
+                        // (setMovementProc() returns true only when it flips proc 0->1),
+                        // so we never create a duplicate return movement
+                        if ($this->setMovementProc($data['moveid'])) {
+                            $bounceTime = $units->getWalkingTroopsTime($from['wref'], $data['to'], $from['owner'], $owntribe, $data, 1, 't');
+                            $bounceEnd  = $database->getArtifactsValueInfluence($from['owner'], $from['wref'], 2, $bounceTime) + $AttackArrivalTime;
+                            $database->addMovement(4, $data['to'], $from['wref'], $data['ref'], $AttackArrivalTime, $bounceEnd);
+                        }
+                        $data_num++;
+                        continue;
+                    }
 
                     $this->handleEvasion($data, $DefenderID, $DefenderUnit, $targettribe, $vt['evasion'], $vt['maxevasion'], $vt['gold'], $vt['cannotsend'], $dataarray[$data_num]['attack_type']);
 
@@ -3369,8 +3380,11 @@ class Automation {
                     $this->handleVillageDestruction($village_destroyed, $can_destroy, $data, $to, $varray);
 
                     // remember the razed tile so any follow-up wave still queued in
-                    // this same batch is skipped instead of fighting a phantom
-                    // (now-deleted) village — see the guard at the top of the loop (issue #298)
+                    // this same batch bounces home instead of fighting a phantom
+                    // (now-deleted) village. Needed on top of the $to['wref'] check
+                    // because getMInfo() is cached: a same-batch wave would still see
+                    // the stale "alive" village row — see the guard right after
+                    // resolveVillageTarget() (issue #298).
                     if ($village_destroyed == 1 && $can_destroy == 1) {
                         $razedTargets[$data['to']] = true;
                     }


### PR DESCRIPTION

The reopened case showed the first fix (#309) wasn't enough. The two waves
in the test land one second apart (12:27:10 / 12:27:11), so they're resolved
in **two separate ticks** — and #309's guard was an in-memory set, empty at
the second tick. The follow-up wave (moveid 5125, sort_type=3, proc=0) is
then re-resolved against the already-deleted village, reports against "[?]",
and its return is computed from a NULL wref → bogus arrival, looping forever.
The DB you pasted also shows DelVillage() doesn't reliably bounce every
in-flight wave (5125 stays sort_type=3 proc=0), so a per-batch guard can't fix
this on its own.

New fix (separate PR, follow-up to #309): detect the razed target from DB
truth instead of an in-memory set. After resolveVillageTarget(), if the
village is gone (`$to['wref']` is NULL) or it was razed earlier in the same
batch, bounce the whole army straight home and mark the movement processed,
instead of fighting a phantom village. It self-heals the attacks already
stuck at proc=0 (they get bounced on the next tick), and never duplicates a
return DelVillage() already created.

I haven't tested it in-game — @Shadowss could you verify it? Repro: 2 cata
waves timed ~1 second apart (so they resolve in different ticks), the first
razing the village.

### Releasing returns already stranded with a corrupted arrival time

Stuck **attacks** (sort_type=3) self-heal once the fix is deployed. But any
**return** (sort_type=4) already written with a bogus endtime won't — release
those manually. Replace `PREFIX_` with your `TB_PREFIX`.

First inspect what's stuck (returns still in flight from a tile that is now an
empty valley):

```sql
SELECT m.moveid, m.`from`, m.`to`, m.ref,
       FROM_UNIXTIME(m.starttime) AS started,
       FROM_UNIXTIME(m.endtime)   AS arrives
FROM PREFIX_movement m
JOIN PREFIX_wdata  w ON w.id   = m.`from`
LEFT JOIN PREFIX_vdata v ON v.wref = m.`from`
WHERE m.proc = 0
  AND m.sort_type = 4          -- returning troops
  AND w.occupied = 0           -- tile is now an e
  AND v.wref IS NULL           -- the village is r
ORDER BY m.endtime;
```

Then bring those troops home on the next tick (same WHERE clause, so it only
touches the rows listed above):

```sql
UPDATE PREFIX_movement m
JOIN PREFIX_wdata  w ON w.id   = m.`from`
LEFT JOIN PREFIX_vdata v ON v.wref = m.`from`
SET m.endtime = UNIX_TIMESTAMP()
WHERE m.proc = 0
  AND m.sort_type = 4
  AND w.occupied = 0
  AND v.wref IS NULL;
```

Run the SELECT first and check the rows look right before running the UPDATE.
