### PR TITLE
fix(combat): bounce attacks home when a multi-wave razes their target [#298]

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -2967,18 +2967,6 @@ class Automation {
 
             // calculate battles
             foreach($dataarray as $data) {
-                // If an earlier attack in this same batch razed the target village,
-                // its still-in-flight follow-up waves were already bounced straight
-                // home by DelVillage() (issue #298). Re-resolving them here would
-                // fight a now-deleted (phantom) village: getMInfo() returns NULL
-                // vdata columns, so the return trip is computed from a NULL wref
-                // (NULL coordinates) — yielding a bogus arrival time that strands
-                // the troops — and would also duplicate the bounce. Skip them.
-                if (isset($razedTargets[$data['to']])) {
-                    $data_num++;
-                    continue;
-                }
-
                 //set base things
 				$totaltraped_att = 0;
 				for($i = 1; $i <= 11; $i++) ${'traped'.$i} = 0;
@@ -3029,6 +3017,29 @@ class Automation {
                     $wallid       = $vt['wallid'];
                     $tblevel      = $vt['tblevel'];
                     $stonemason   = $vt['stonemason'];
+
+                    // Issue #298: the target village no longer exists — it was razed
+                    // either earlier in this same batch ($razedTargets), or in an
+                    // earlier tick whose still-in-flight follow-up waves DelVillage()
+                    // failed to bounce. getMInfo() then returns NULL vdata columns
+                    // ($to['wref'] is NULL), so resolving a battle here would fight a
+                    // phantom village and compute the return trip from NULL coordinates
+                    // — a bogus arrival time that strands the troops in an endless loop
+                    // (report against "[?]"). Bounce the whole army straight home
+                    // instead, exactly like DelVillage() does for in-flight attacks,
+                    // and mark the movement processed so it stops being re-fetched.
+                    if (isset($razedTargets[$data['to']]) || empty($to['wref'])) {
+                        // only own the bounce if DelVillage() hasn't already handled it
+                        // (setMovementProc() returns true only when it flips proc 0->1),
+                        // so we never create a duplicate return movement
+                        if ($this->setMovementProc($data['moveid'])) {
+                            $bounceTime = $units->getWalkingTroopsTime($from['wref'], $data['to'], $from['owner'], $owntribe, $data, 1, 't');
+                            $bounceEnd  = $database->getArtifactsValueInfluence($from['owner'], $from['wref'], 2, $bounceTime) + $AttackArrivalTime;
+                            $database->addMovement(4, $data['to'], $from['wref'], $data['ref'], $AttackArrivalTime, $bounceEnd);
+                        }
+                        $data_num++;
+                        continue;
+                    }
 
                     $this->handleEvasion($data, $DefenderID, $DefenderUnit, $targettribe, $vt['evasion'], $vt['maxevasion'], $vt['gold'], $vt['cannotsend'], $dataarray[$data_num]['attack_type']);
 
@@ -3369,8 +3380,11 @@ class Automation {
                     $this->handleVillageDestruction($village_destroyed, $can_destroy, $data, $to, $varray);
 
                     // remember the razed tile so any follow-up wave still queued in
-                    // this same batch is skipped instead of fighting a phantom
-                    // (now-deleted) village — see the guard at the top of the loop (issue #298)
+                    // this same batch bounces home instead of fighting a phantom
+                    // (now-deleted) village. Needed on top of the $to['wref'] check
+                    // because getMInfo() is cached: a same-batch wave would still see
+                    // the stale "alive" village row — see the guard right after
+                    // resolveVillageTarget() (issue #298).
                     if ($village_destroyed == 1 && $can_destroy == 1) {
                         $razedTargets[$data['to']] = true;
                     }

--- a/GameEngine/Database.php
+++ b/GameEngine/Database.php
@@ -4239,9 +4239,23 @@ class MYSQLi_DB implements IDbConnection {
         $q = "DELETE FROM ".TB_PREFIX."movement where proc = 0 AND ((`to` IN($wrefs) AND sort_type = 4) OR (`from` IN($wrefs) AND sort_type = 3))";
         $this->query($q);
         $this->removeOases($wref, 1);
-        
-        $getmovement = $this->getMovement(3, $wref, 1);
-        
+
+        // In-flight attacks still heading for the deleted village(s) must be
+        // bounced straight home. Query them directly instead of using
+        // getMovement(3, $wref, 1): when passed an array, getMovement() returns
+        // the WHOLE movement cache (a map of "type.village.mode" => record list),
+        // not the flat record list this loop expects — so $movedata['moveid'] /
+        // ['starttime'] were NULL and the follow-up waves were never bounced,
+        // leaving them stuck at sort_type=3/proc=0 and looping forever once the
+        // village is gone. Pre-dates the sendunitsComplete() split (issue #298).
+        $q = "SELECT * FROM ".TB_PREFIX."movement, ".TB_PREFIX."attacks
+              WHERE ".TB_PREFIX."movement.`to` IN($wrefs)
+                AND ".TB_PREFIX."movement.ref = ".TB_PREFIX."attacks.id
+                AND ".TB_PREFIX."movement.proc = 0
+                AND ".TB_PREFIX."movement.sort_type = 3
+              ORDER BY endtime ASC";
+        $getmovement = $this->mysqli_fetch_all(mysqli_query($this->dblink, $q));
+
         $moveIDs = [];
         $time = microtime(true);
         $types = [];


### PR DESCRIPTION
You nailed it — it's a legacy bug, not the split. I found the actual root
cause in `Database::DelVillage()`.

When a village is razed, DelVillage() must bounce every attack still heading
for it back home. It did that via `getMovement(3, $wref, 1)` — but `$wref` is
an array there (DelVillage wraps the scalar), and `getMovement()` returns the
**whole movement cache** when passed an array (`return $array_passed ?
self::$marketMovementCache : ...`), a `"type.village.mode" => record-list` map,
not the flat record list the bounce loop iterates. So `$movedata['moveid']` /
`['starttime']` were NULL, no follow-up wave was ever bounced, and any wave
that hadn't landed yet when the village fell stayed at sort_type=3 / proc=0:
re-resolved every tick against a now-deleted village, reported against "[?]",
returning on a bogus (NULL-coordinate) arrival time, looping forever. It only
shows with >=2 waves (a lone wave has nothing to bounce) — matching "a lot of
cata attacks". DelVillage() is the only caller that consumes an array-passed
getMovement() result; every other caller passes a scalar and gets a flat list.

Fix (PR updated, 2 commits):
1. DelVillage() now queries the in-flight attacks directly, so the bounce loop
   gets a proper flat record list and every follow-up wave is sent home.
2. sendunitsComplete() also bounces an attack home (instead of fighting a
   phantom) when its target village no longer exists. This self-heals the
   attacks already stuck at proc=0 on a running server: they get bounced on the
   next tick once this is deployed.

I haven't tested it in-game — could you verify it? Repro: 2 cata waves timed a
second or two apart (so the first razes the village while the second is still
in flight).

### Releasing returns already stranded with a corrupted arrival time

Stuck **attacks** (sort_type=3) self-heal once this is deployed. But any
**return** (sort_type=4) already written with a bogus endtime won't — release
those manually. Replace `PREFIX_` with your `TB_PREFIX`.

Inspect first (returns still in flight from a tile that is now an empty valley):

```sql
SELECT m.moveid, m.`from`, m.`to`, m.ref,
       FROM_UNIXTIME(m.starttime) AS started,
       FROM_UNIXTIME(m.endtime)   AS arrives
FROM PREFIX_movement m
JOIN PREFIX_wdata  w ON w.id   = m.`from`
LEFT JOIN PREFIX_vdata v ON v.wref = m.`from`
WHERE m.proc = 0
  AND m.sort_type = 4          -- returning troops
  AND w.occupied = 0           -- tile is now an empty valley
  AND v.wref IS NULL           -- the village is really gone
ORDER BY m.endtime;
```

Then bring them home on the next tick (same WHERE clause):

```sql
UPDATE PREFIX_movement m
JOIN PREFIX_wdata  w ON w.id   = m.`from`
LEFT JOIN PREFIX_vdata v ON v.wref = m.`from`
SET m.endtime = UNIX_TIMESTAMP()
WHERE m.proc = 0
  AND m.sort_type = 4
  AND w.occupied = 0
  AND v.wref IS NULL;
```

Run the SELECT first and check the rows before running the UPDATE.