### PR TITLE
fix(troops): apply Tournament Square bonus only beyond the threshold [#304]

### DIFF
--- a/GameEngine/Admin/database.php
+++ b/GameEngine/Admin/database.php
@@ -676,8 +676,16 @@ class adm_DB {
         }
         $distance = SQRT(POW($xdistance, 2) + POW($ydistance, 2));
         $speed = $ref;
-        if ($this->getTypeLevel(14, $vid)!= 0 && $distance >= TS_THRESHOLD) {
-            $speed = $speed * ($bid14[$this->getTypeLevel(14, $vid)]['attri'] / 100);
+        $tSquareLevel = $this->getTypeLevel(14, $vid);
+
+        if ($tSquareLevel != 0 && $distance >= TS_THRESHOLD && $speed > 0) {
+            // Tournament Square only speeds up the part of the journey beyond
+            // the threshold (issue #304): the first TS_THRESHOLD tiles are
+            // walked at base speed and the remainder at the boosted speed.
+            $boostedSpeed = $speed * ($bid14[$tSquareLevel]['attri'] / 100);
+            $time = (TS_THRESHOLD / $speed) + (($distance - TS_THRESHOLD) / $boostedSpeed);
+
+            return round($time * 3600 / INCREASE_SPEED);
         }
 
         if ($speed!= 0) {

--- a/GameEngine/Generator.php
+++ b/GameEngine/Generator.php
@@ -98,8 +98,16 @@ class MyGenerator
 
 			$tSquareLevel = $database->getFieldLevelInVillage($vid, 14);
 
-			if ($tSquareLevel > 0 && $distance >= TS_THRESHOLD) {
-				$speed *= ($bid14[$tSquareLevel]['attri'] / 100);
+			if ($tSquareLevel > 0 && $distance >= TS_THRESHOLD && $speed > 0) {
+				// Tournament Square only speeds up the part of the journey
+				// beyond the threshold: the first TS_THRESHOLD tiles are walked
+				// at base speed and the remainder at the boosted speed.
+				// Multiplying the whole distance made far targets arrive sooner
+				// than near ones (issue #304).
+				$boostedSpeed = $speed * ($bid14[$tSquareLevel]['attri'] / 100);
+				$time = (TS_THRESHOLD / $speed) + (($distance - TS_THRESHOLD) / $boostedSpeed);
+
+				return round($time * 3600 / INCREASE_SPEED);
 			}
 		}
 


### PR DESCRIPTION
Fixes #304.

`procDistanceTime()` multiplied the **whole** travel distance by the Tournament Square speed factor as soon as `distance >= TS_THRESHOLD`, instead of only the part beyond the threshold. This creates a cliff at the threshold, so a target just past it arrives dramatically sooner than a nearer one — e.g. a village 41 tiles away raided faster than one 18 tiles away.

At TS level 20 the factor is `attri/100 = ×3`. With base speed `s` (time ∝ distance/speed), the buggy times match the reporter's screenshots within 0.5 %:

| target | distance | buggy (1/s) | reported |
|---|---|---|---|
| farm29 | 18.1 (< 20, no bonus) | 18.10 | 0:12:05 |
| farm28 | 41 (÷3 whole trip) | 13.67 | 0:09:07 |
| farm1 | 51.9 (÷3 whole trip) | 17.30 | 0:11:32 |

**Fix:** walk the first `TS_THRESHOLD` tiles at base speed and only the remainder at the boosted speed:
`time = TS_THRESHOLD/speed + (distance - TS_THRESHOLD)/(speed × factor)`. Times become 18.10 / 27.0 / 30.63 — monotonic with distance, so the square still helps but never inverts the order. Merchants are unaffected (they go through the fixed-speed `!$mode` branch).

This is a long-standing bug, unrelated to the Generator refactor (that commit only reformatted the same whole-distance multiplication). The same fix is applied to the duplicate `procDistanceTime()` in `Admin/database.php` used by the admin troop-return helper.

**Not tested in-game on my side**