### PR TITLE
fix(combat): match building type by 't' suffix in Battle::getTypeLevel [#294]

### DIFF
--- a/GameEngine/Battle.php
+++ b/GameEngine/Battle.php
@@ -390,15 +390,19 @@ class Battle {
      ******************************************************************/
     foreach ($resourcearray as $key => $value) {
 
-        // faster than array_keys + strpos + preg_replace
+        // The building TYPE is stored in the 'f<n>t' columns of fdata (e.g. the
+        // Brewery on slot 20 is 'f20t' == 35); the matching level lives in 'f<n>'.
+        // Match on the 't' SUFFIX, not the first character — a previous rewrite
+        // tested $key[0] === 't', which never matched 'f<n>t' and made this
+        // return 0 for every building (issue #294: Brewery bonus never applied).
+        // Mirrors Building::getTypeLevel()/Automation::getTypeLevel().
         if (
             isset($value)
             && $value == $tid
-            && isset($key[0])
-            && $key[0] === 't'
+            && strpos($key, 't') !== false
         ) {
 
-            $keyholder[] = (int)substr($key, 1);
+            $keyholder[] = (int)preg_replace('/[^0-9]/', '', $key);
         }
     }
     $element = count($keyholder);


### PR DESCRIPTION
The Brewery Mead-Festival attack bonus never took effect, even with an active
festival, because `Battle::getTypeLevel()` could never locate the building.

In `fdata`, each slot stores its level in `f<n>` and its building TYPE in
`f<n>t` (e.g. a Brewery on slot 20 is `f20t` == 35). `getTypeLevel()` scanned
for the type columns with `$key[0] === 't'` — but those keys start with `f`,
not `t`, so the test never matched → `keyholder` stayed empty →
`getTypeLevel(35, capital)` returned 0 → `$bid35[0]` is unset → the bonus was
always 0, festival or not.

This regression was introduced by the "Full refactor of Battle" commit
(27e9a9a7), which replaced the previous correct scan (`strpos($key, 't')`,
still used by `Building::getTypeLevel()` and `Automation::getTypeLevel()`) with
the first-character test. It therefore predates the #294 festival gating, which
merely wired an already-broken lookup — which is why:

- catapults randomised correctly (Units.php uses `getFieldLevelInVillage`);
- the attack bonus never worked (Battle.php uses this `getTypeLevel`);
- a standalone diagnostic showed `bonus=10` (it rescanned `f20t` by hand).

Fix: match the `t` SUFFIX and strip non-digits for the slot number, restoring
the pre-refactor behaviour and aligning with `Building::`/`Automation::getTypeLevel()`.
The only caller is the Brewery bonus block, so the change is scoped to that path.

Tested in-game on a fresh install: Teuton attacker, capital Brewery level 10,
identical army vs identical defender — with the festival active the attacker now
takes visibly fewer losses (+10% attack), and no change without it.