### PR TITLE
fix(admin): read config template from the version-controlled copy [#322]

### DIFF
--- a/GameEngine/Admin/Mods/config_template.php
+++ b/GameEngine/Admin/Mods/config_template.php
@@ -1,0 +1,47 @@
+<?php
+#################################################################################
+##              -= YOU MAY NOT REMOVE OR CHANGE THIS NOTICE =-                 ##
+## --------------------------------------------------------------------------- ##
+##  Filename       config_template.php                                         ##
+##  Project        TravianZ                                                     ##
+##  License        TravianZ Project                                            ##
+#################################################################################
+
+// Shared helper for the admin "Server Settings" Mods, which regenerate
+// GameEngine/config.php from the constant_format.tpl template.
+//
+// Issue #322: each Mod used to read the install-time copy
+// GameEngine/Admin/Mods/constant_format.tpl. That copy is written once by the
+// installer and is gitignored, so a code update NEVER refreshes it. When a new
+// line is added to config.php (e.g. the per-user LANG block, issue #166),
+// servers installed before that change keep the stale copy and the admin panel
+// silently rewrites config.php without the new line.
+//
+// Fix: prefer the version-controlled template (install/data/constant_format.tpl)
+// so shipping a new template via git is enough. Fall back to the install-time
+// copy only when the install folder was deleted (a common hardening step once
+// setup is done).
+
+if (!function_exists('admin_config_template_path')) {
+
+    // Absolute path of the template to use, or false when none is available.
+    function admin_config_template_path() {
+        $canonical = __DIR__ . '/../../../install/data/constant_format.tpl';
+        if (is_file($canonical)) {
+            return $canonical;
+        }
+
+        $local = __DIR__ . '/constant_format.tpl';
+        return is_file($local) ? $local : false;
+    }
+
+    function admin_config_template_available() {
+        return admin_config_template_path() !== false;
+    }
+
+    // Raw template contents (placeholders untouched), or false when unavailable.
+    function admin_config_template_contents() {
+        $path = admin_config_template_path();
+        return $path !== false ? file_get_contents($path) : false;
+    }
+}

--- a/GameEngine/Admin/Mods/editAdminInfo.php
+++ b/GameEngine/Admin/Mods/editAdminInfo.php
@@ -20,7 +20,9 @@ csrf_verify();
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 
-if (!file_exists('constant_format.tpl')) {
+require_once(__DIR__ . '/config_template.php');
+
+if (!admin_config_template_available()) {
     die(
         'You seem to be running a new version of TravianZ which was installed using an old installer.<br />' .
         'Please download <strong>constant_format.tpl</strong> file and copy it into the <strong>GameEngine/Admin/Mods</strong> ' .
@@ -72,7 +74,7 @@ $fh = fopen($myFile, 'w') or die("<br/><br/><br/>Can't open file: GameEngine\con
 		$NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM = (NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM == false ? 'false' : 'true');
 		$NEW_FUNCTIONS_MILESTONES = (NEW_FUNCTIONS_MILESTONES == false ? 'false' : 'true');
 
-		$text = file_get_contents("constant_format.tpl");
+		$text = admin_config_template_contents();
 		$text = preg_replace("'%ERRORREPORT%'", $ERRORREPORT, $text);
 		$text = preg_replace("'%ERROR%'", $ERRORREPORT, $text);
 		$text = preg_replace("'%SERVERNAME%'", SERVER_NAME, $text);

--- a/GameEngine/Admin/Mods/editExtraSet.php
+++ b/GameEngine/Admin/Mods/editExtraSet.php
@@ -20,7 +20,9 @@ csrf_verify();
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 
-if (!file_exists('constant_format.tpl')) {
+require_once(__DIR__ . '/config_template.php');
+
+if (!admin_config_template_available()) {
     die(
         'You seem to be running a new version of TravianZ which was installed using an old installer.<br />' .
         'Please download <strong>constant_format.tpl</strong> file and copy it into the <strong>GameEngine/Admin/Mods</strong> ' .
@@ -71,7 +73,7 @@ $fh = fopen($myFile, 'w') or die("<br/><br/><br/>Can't open file: GameEngine\con
 		$NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM = (NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM == false ? 'false' : 'true');
 		$NEW_FUNCTIONS_MILESTONES = (NEW_FUNCTIONS_MILESTONES == false ? 'false' : 'true');
 
-		$text = file_get_contents("constant_format.tpl");
+		$text = admin_config_template_contents();
 		$text = preg_replace("'%ERRORREPORT%'", ERROR_REPORT, $text);
 		$text = preg_replace("'%ERROR%'", ERROR_REPORT, $text);
 		$text = preg_replace("'%SERVERNAME%'", SERVER_NAME, $text);

--- a/GameEngine/Admin/Mods/editLogSet.php
+++ b/GameEngine/Admin/Mods/editLogSet.php
@@ -20,7 +20,9 @@ csrf_verify();
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 
-if (!file_exists('constant_format.tpl')) {
+require_once(__DIR__ . '/config_template.php');
+
+if (!admin_config_template_available()) {
     die(
         'You seem to be running a new version of TravianZ which was installed using an old installer.<br />' .
         'Please download <strong>constant_format.tpl</strong> file and copy it into the <strong>GameEngine/Admin/Mods</strong> ' .
@@ -67,7 +69,7 @@ $fh = fopen($myFile, 'w') or die("<br/><br/><br/>Can't open file: GameEngine\con
 		$NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM = (NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM == false ? 'false' : 'true');
 		$NEW_FUNCTIONS_MILESTONES = (NEW_FUNCTIONS_MILESTONES == false ? 'false' : 'true');
 
-		$text = file_get_contents("constant_format.tpl");
+		$text = admin_config_template_contents();
 		$text = preg_replace("'%ERRORREPORT%'", $ERRORREPORT, $text);
 		$text = preg_replace("'%ERROR%'", $ERRORREPORT, $text);
 		$text = preg_replace("'%SERVERNAME%'", SERVER_NAME, $text);

--- a/GameEngine/Admin/Mods/editNewFunctions.php
+++ b/GameEngine/Admin/Mods/editNewFunctions.php
@@ -20,7 +20,9 @@ csrf_verify();
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 
-if (!file_exists('constant_format.tpl')) {
+require_once(__DIR__ . '/config_template.php');
+
+if (!admin_config_template_available()) {
     die(
         'You seem to be running a new version of TravianZ which was installed using an old installer.<br />' .
         'Please download <strong>constant_format.tpl</strong> file and copy it into the <strong>GameEngine/Admin/Mods</strong> ' .
@@ -32,7 +34,7 @@ if (!file_exists('constant_format.tpl')) {
 $myFile = "../../config.php";
 $fh = fopen($myFile, 'w') or die("<br/><br/><br/>Can't open file: GameEngine\config.php");
 
-        $text = file_get_contents("constant_format.tpl");
+        $text = admin_config_template_contents();
 
 		$SUPPORT_MSGS_IN_ADMIN = (ADMIN_RECEIVE_SUPPORT_MESSAGES == false ? 'false' : 'true');
 		$ADMINS_RAIDABLE = (ADMIN_ALLOW_INCOMING_RAIDS == false ? 'false' : 'true');

--- a/GameEngine/Admin/Mods/editNewsboxSet.php
+++ b/GameEngine/Admin/Mods/editNewsboxSet.php
@@ -20,7 +20,9 @@ csrf_verify();
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 
-if (!file_exists('constant_format.tpl')) {
+require_once(__DIR__ . '/config_template.php');
+
+if (!admin_config_template_available()) {
     die(
         'You seem to be running a new version of TravianZ which was installed using an old installer.<br />' .
         'Please download <strong>constant_format.tpl</strong> file and copy it into the <strong>GameEngine/Admin/Mods</strong> ' .
@@ -73,7 +75,7 @@ $fh = fopen($myFile, 'w') or die("<br/><br/><br/>Can't open file: GameEngine\con
 		$NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM = (NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM == false ? 'false' : 'true');
 		$NEW_FUNCTIONS_MILESTONES = (NEW_FUNCTIONS_MILESTONES == false ? 'false' : 'true');
 
-		$text = file_get_contents("constant_format.tpl");
+		$text = admin_config_template_contents();
 		$text = preg_replace("'%ERRORREPORT%'", $ERRORREPORT, $text);
 		$text = preg_replace("'%ERROR%'", $ERRORREPORT, $text);
 		$text = preg_replace("'%SERVERNAME%'", SERVER_NAME, $text);

--- a/GameEngine/Admin/Mods/editPlusSet.php
+++ b/GameEngine/Admin/Mods/editPlusSet.php
@@ -21,7 +21,9 @@ include_once("../../Database.php");
 include_once("../../config.php");
 $id = (int) $_POST['id'];
 
-if (!file_exists('constant_format.tpl')) {
+require_once(__DIR__ . '/config_template.php');
+
+if (!admin_config_template_available()) {
     die(
         'You seem to be running a new version of TravianZ which was installed using an old installer.<br />' .
         'Please download <strong>constant_format.tpl</strong> file and copy it into the <strong>GameEngine/Admin/Mods</strong> ' .
@@ -33,7 +35,7 @@ if (!file_exists('constant_format.tpl')) {
 $myFile = "../../config.php";
 $fh = fopen($myFile, 'w') or die("<br/><br/><br/>Can't open file: GameEngine\config.php");
 
-		$text = file_get_contents("constant_format.tpl");
+		$text = admin_config_template_contents();
 
 		$SUPPORT_MSGS_IN_ADMIN = (ADMIN_RECEIVE_SUPPORT_MESSAGES == false ? 'false' : 'true');
 		$ADMINS_RAIDABLE = (ADMIN_ALLOW_INCOMING_RAIDS == false ? 'false' : 'true');

--- a/GameEngine/Admin/Mods/editServerSet.php
+++ b/GameEngine/Admin/Mods/editServerSet.php
@@ -20,7 +20,9 @@ csrf_verify();
 include_once("../../Database.php");
 $id = (int) $_POST['id'];
 
-if (!file_exists('constant_format.tpl')) {
+require_once(__DIR__ . '/config_template.php');
+
+if (!admin_config_template_available()) {
     die(
         'You seem to be running a new version of TravianZ which was installed using an old installer.<br />' .
         'Please download <strong>constant_format.tpl</strong> file and copy it into the <strong>GameEngine/Admin/Mods</strong> ' .
@@ -66,7 +68,7 @@ $fh = fopen($myFile, 'w') or die("<br/><br/><br/>Can't open file: GameEngine\con
 		$NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM = (NEW_FUNCTIONS_SPECIAL_MEDALS_SYSTEM == false ? 'false' : 'true');
 		$NEW_FUNCTIONS_MILESTONES = (NEW_FUNCTIONS_MILESTONES == false ? 'false' : 'true');
 
-		$text = file_get_contents("constant_format.tpl");
+		$text = admin_config_template_contents();
 		$text = preg_replace("'%ERRORREPORT%'", $_POST['error'], $text);
 		$text = preg_replace("'%ERROR%'", $_POST['error'], $text);
 		$text = preg_replace("'%SERVERNAME%'", $_POST['servername'], $text);


### PR DESCRIPTION
The admin "Server Settings" Mods regenerate `GameEngine/config.php` from
`constant_format.tpl`, replacing only placeholders such as `%LANG%`. They read
`GameEngine/Admin/Mods/constant_format.tpl`, a copy written once by the installer
and gitignored, so a code update never refreshes it. On a server installed before
a line was added to the template (e.g. the per-user LANG block, issue #166), that
stale copy still holds the old single-line language section, so saving any setting
silently rewrites `config.php` without the per-user LANG derivation — issue #322,
where `config.php` collapses to just `define("SERVER_LANG", ...)`.

Fix: prefer the version-controlled template `install/data/constant_format.tpl` so
shipping an updated template via git is enough; fall back to the install-time copy
only when the `install/` folder was removed. Extracted into a shared
`config_template.php` helper and wired into all seven config-writing Mods
(`editServerSet`, `editExtraSet`, `editNewFunctions`, `editNewsboxSet`,
`editAdminInfo`, `editLogSet`, `editPlusSet`). Read-only change (no filesystem
writes), placeholder substitution is untouched.