### PR TITLE
Fix: %ALLIANCEBONUSES% left unsubstituted in config.php by ACP saves

### DIFF
--- a/GameEngine/Admin/Mods/config_template.php
+++ b/GameEngine/Admin/Mods/config_template.php
@@ -258,6 +258,13 @@ if (!function_exists('admin_config_template_path')) {
             }
         }
 
+        if (strpos($text, '%ALLIANCEBONUSES%') !== false) {
+            $allianceBonuses = (defined('NEW_FUNCTIONS_ALLIANCE_BONUSES') && NEW_FUNCTIONS_ALLIANCE_BONUSES)
+                ? 'true'
+                : 'false';
+            $text = str_replace('%ALLIANCEBONUSES%', $allianceBonuses, $text);
+        }
+
         // Pachetul grafic si comutatorul de pachete proprii.
         //
         // ATENTIE LA ORDINE: acest bloc trebuie sa ruleze DUPA bucla de

--- a/GameEngine/Admin/Mods/editNewFunctions.php
+++ b/GameEngine/Admin/Mods/editNewFunctions.php
@@ -34,7 +34,9 @@ if (!admin_config_template_available()) {
 $myFile = "../../config.php";
 $fh = fopen($myFile, 'w') or die("<br/><br/><br/>Can't open file: GameEngine\config.php");
 
-        $text = admin_config_template_contents();
+        $text = admin_config_template_contents(array(
+            '%ALLIANCEBONUSES%' => (isset($_POST['alliance_bonuses']) && $_POST['alliance_bonuses'] === 'true') ? 'true' : 'false',
+        ));
 
 		$SUPPORT_MSGS_IN_ADMIN = (ADMIN_RECEIVE_SUPPORT_MESSAGES == false ? 'false' : 'true');
 		$ADMINS_RAIDABLE = (ADMIN_ALLOW_INCOMING_RAIDS == false ? 'false' : 'true');
@@ -112,7 +114,6 @@ $fh = fopen($myFile, 'w') or die("<br/><br/><br/>Can't open file: GameEngine\con
 		tz_config_set($text, '%HOMEPAGE%', HOMEPAGE);
 		tz_config_set($text, '%SERVER%', SERVER);
 		tz_config_set($text, '%NEW_FUNCTIONS_OASIS%', $_POST['new_functions_oasis'] ?? '');
-		tz_config_set($text, '%ALLIANCEBONUSES%', $_POST['alliance_bonuses'] ?? 'false');
 		tz_config_set($text, '%NEW_FUNCTIONS_ALLIANCE_INVITATION%', $_POST['new_functions_alliance_invitation'] ?? '');
 		tz_config_set($text, '%NEW_FUNCTIONS_EMBASSY_MECHANICS%', $_POST['new_functions_embassy_mechanics'] ?? '');
 		tz_config_set($text, '%NEW_FUNCTIONS_FORUM_POST_MESSAGE%', $_POST['new_functions_forum_post_message'] ?? '');


### PR DESCRIPTION
When saving any ACP form other than "New Functions", `config.php` is
regenerated from `install/data/constant_format.tpl`. The placeholder
`%ALLIANCEBONUSES%` (added with the T4 Alliance Bonuses feature) is only
handled by `editNewFunctions.php`, so every other module writes it
literally:

```php
define("NEW_FUNCTIONS_ALLIANCE_BONUSES", %ALLIANCEBONUSES%);
```

This is a fatal parse error and takes the whole server down with HTTP 500
until `config.php` is fixed by hand.

Affects `editServerSet`, `editLogSet`, `editPlusSet`, `editNewsboxSet`,
`editAdminInfo` and `editExtraSet`.

## Steps to reproduce

1. Fresh install from `master`.
2. ACP → Server Configuration, change any value, save.
3. Every page returns 500:

PHP Parse error: syntax error, unexpected token "%", expecting ")"
in GameEngine/config.php on line 150


## The fix

This is the same failure mode already documented for `%GP%` in
`config_template.php`, and the fix follows that pattern. It has two parts:

1. **`config_template.php`** — resolve `%ALLIANCEBONUSES%` centrally in
   `admin_config_template_contents()`, preserving the current constant and
   writing it explicitly as the string `'true'`/`'false'`. This is the
   fallback for every module that does not handle the placeholder itself.

2. **`editNewFunctions.php`** — pass the admin's choice through the
   `$overrides` parameter instead of calling `tz_config_set()` on the
   returned text. Without this, part 1 would consume the placeholder before
   `editNewFunctions` gets to it, and the Alliance Bonuses toggle would
   silently keep its old value on every save.

This mirrors how `%GP%` is already handled: `editServerSet` supplies the
value via `$overrides`, the override loop runs first, and the central block
only acts as a fallback for modules that send nothing.

## Testing

Toggling Alliance Bonuses on and off in the ACP now writes the correct
value, and saving other ACP forms preserves it.

Environment: PHP 8.3, MariaDB 10.11, Debian 12, fresh install from `master`.