### PR TITLE
Add baseline PHP and Docker Compose quality checks

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,49 @@
+name: Quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  php:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - "8.3"
+          - "8.4"
+          - "8.5"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Check PHP syntax and regression tests
+        run: ./scripts/check.sh php
+
+  compose:
+    name: Docker Compose
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate Compose configuration
+        run: ./scripts/check.sh compose
+
+      - name: Run shell contract tests
+        run: ./scripts/check.sh shell

--- a/README.md
+++ b/README.md
@@ -422,8 +422,17 @@ docker compose up -d
 # Logs
 docker compose logs -f web
 
-# Validate PHP files
-find . -name '*.php' -not -path './var/*' -print0 | xargs -0 -n1 php -l
+# Run every local quality check
+./scripts/check.sh
+
+# Run only PHP syntax checks and regression tests
+./scripts/check.sh php
+
+# Run all zero-dependency regression and contract tests
+./scripts/check.sh test
+
+# Validate Docker Compose
+./scripts/check.sh compose
 ```
 
 Repository references:

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repository_root"
+
+lint_php()
+{
+	local file
+	local linted=0
+
+	while IFS= read -r -d '' file; do
+		# This installer source is a PHP generator template. Its %TOKEN%
+		# placeholders are replaced before the generated file is executed.
+		if [[ "$file" == "install/data/constant_format.tpl" ]]; then
+			continue
+		fi
+
+		php -l "$file" > /dev/null
+		linted=$((linted + 1))
+	done < <(git ls-files -z -- '*.php' '*.tpl')
+
+	echo "PHP syntax check passed for ${linted} tracked files."
+}
+
+run_php_tests()
+{
+	local file
+	local tested=0
+
+	while IFS= read -r -d '' file; do
+		if [[ "$file" != *Test.php ]]; then
+			continue
+		fi
+
+		echo "Running ${file}"
+		php "$file"
+		tested=$((tested + 1))
+	done < <(git ls-files -z -- 'tests/*.php' 'tests/**/*.php')
+
+	if [[ "$tested" -eq 0 ]]; then
+		echo "No zero-dependency PHP tests found."
+	else
+		echo "PHP tests passed for ${tested} files."
+	fi
+}
+
+run_shell_tests()
+{
+	local file
+	local tested=0
+
+	while IFS= read -r -d '' file; do
+		if [[ "$file" != *.sh ]]; then
+			continue
+		fi
+
+		echo "Running ${file}"
+		sh -n "$file"
+		sh "$file"
+		tested=$((tested + 1))
+	done < <(git ls-files -z -- 'tests/*.sh' 'tests/**/*.sh')
+
+	if [[ "$tested" -eq 0 ]]; then
+		echo "No shell contract tests found."
+	else
+		echo "Shell contract tests passed for ${tested} files."
+	fi
+}
+
+validate_compose()
+{
+	if ! command -v docker > /dev/null 2>&1; then
+		echo "Docker is required for Compose validation." >&2
+		exit 1
+	fi
+
+	docker compose config --quiet
+	echo "Docker Compose configuration is valid."
+}
+
+usage()
+{
+	echo "Usage: $0 {all|php|lint|test|shell|compose}" >&2
+	exit 2
+}
+
+case "${1:-all}" in
+	all)
+		lint_php
+		run_php_tests
+		validate_compose
+		run_shell_tests
+		;;
+	php)
+		lint_php
+		run_php_tests
+		;;
+	lint)
+		lint_php
+		;;
+	test)
+		run_php_tests
+		run_shell_tests
+		;;
+	shell)
+		run_shell_tests
+		;;
+	compose)
+		validate_compose
+		;;
+	*)
+		usage
+		;;
+esac


### PR DESCRIPTION
## Summary

This pull request adds a small, dependency-free quality gate for TravianZ.

It introduces:

- one local check script with focused `php`, `lint`, `test`, `shell`, and `compose` modes;
- GitHub Actions syntax checks on PHP 8.3, 8.4, and 8.5;
- automatic execution of zero-dependency PHP regression tests and shell contract tests as they are added;
- Docker Compose configuration validation;
- documented local commands in the README.

## Problem

The repository currently has no automated pull-request checks. The README contains a manual `find ... php -l` command, but that command:

- depends on each contributor remembering to run it;
- checks only `.php` files;
- does not cover PHP embedded in tracked `.tpl` files;
- does not validate `docker-compose.yml`;
- provides no standard place for focused regression or deployment-contract tests.

This makes simple syntax and configuration regressions easy to merge, particularly in a legacy codebase with more than one thousand PHP/template files.

## Solution

### Reusable local check script

`scripts/check.sh` is the single entry point for local and CI validation:

```bash
./scripts/check.sh          # all checks
./scripts/check.sh php      # PHP syntax + PHP regression tests
./scripts/check.sh lint     # syntax only
./scripts/check.sh test     # PHP and shell tests
./scripts/check.sh shell    # shell contract tests only
./scripts/check.sh compose  # Compose configuration
```

The script uses tracked files from Git rather than scanning generated or untracked runtime content.

It checks both `.php` and `.tpl` files. `install/data/constant_format.tpl` is explicitly excluded because it is a generator template containing `%TOKEN%` placeholders that become valid PHP only after installation-time substitution.

Tracked `tests/**/*Test.php` files are executed directly with PHP. Tracked shell files under `tests/` are syntax-checked and then executed with `sh`. This allows small regression tests without requiring Composer, PHPUnit, or another test runner.

### GitHub Actions

The new workflow runs:

- PHP syntax and PHP regression tests on PHP 8.3, 8.4, and 8.5;
- `docker compose config --quiet` in a separate job;
- shell contract tests in the Compose job;
- read-only repository permissions.

The workflow runs for pull requests and pushes to `master`.

## Validation

Performed locally:

- `bash -n scripts/check.sh`
- `./scripts/check.sh php`
  - 1,093 tracked PHP/template files passed syntax checking
- `./scripts/check.sh test`
  - test discovery completed successfully; this isolated branch does not yet contain regression tests
- `./scripts/check.sh compose`
  - Docker Compose configuration passed
- `git diff --check`

## Impact

This changes contributor tooling only. It does not alter game behavior, database state, generated configuration, or the Docker runtime.

## Cross-PR integration check

The script was also exercised in a disposable worktree containing the five related fix branches. A single `./scripts/check.sh` run:

- syntax-checked 1,100 tracked PHP/template files;
- discovered and passed four PHP regression tests;
- validated Docker Compose;
- discovered and passed one shell contract test.

This confirms that test discovery works when independently contributed tests are present.