### PR TITLE
Fix research queue cache population

### DIFF
--- a/GameEngine/Database/DatabaseTroopQueries.php
+++ b/GameEngine/Database/DatabaseTroopQueries.php
@@ -354,8 +354,8 @@ trait DatabaseTroopQueries {
 
 		$q = "SELECT * FROM " . TB_PREFIX . "research where vref = $vid ORDER BY timestamp ASC";
 		$result = mysqli_query($this->dblink,$q);
-        $researchingCache[$vid] = $this->mysqli_fetch_all($result);
-        return $researchingCache[$vid];
+        self::$researchingCache[$vid] = $this->mysqli_fetch_all($result);
+        return self::$researchingCache[$vid];
 	}
 
 	function checkIfResearched($vref, $unit, $use_cache = true) {

--- a/tests/regression/GetResearchingCacheTest.php
+++ b/tests/regression/GetResearchingCacheTest.php
@@ -1,0 +1,70 @@
+<?php
+
+if (function_exists('mysqli_query')) {
+    $command = escapeshellarg(PHP_BINARY)
+        . ' -d disable_functions=mysqli_query '
+        . escapeshellarg(__FILE__);
+
+    passthru($command, $status);
+    exit($status);
+}
+
+if (!function_exists('mysqli_query')) {
+    function mysqli_query($connection, $query)
+    {
+        $GLOBALS['queryCount']++;
+
+        return $query;
+    }
+}
+
+define('TB_PREFIX', 'test_');
+
+require_once __DIR__ . '/../../GameEngine/Database/DatabaseTroopQueries.php';
+
+final class ResearchingCacheHarness
+{
+    use DatabaseTroopQueries;
+
+    public $dblink;
+    public $rows = [];
+
+    private static $researchingCache = [];
+
+    private static function returnCachedContent(&$cache, $key)
+    {
+        return isset($cache[$key]) && !empty($cache[$key])
+            ? $cache[$key]
+            : null;
+    }
+
+    public function mysqli_fetch_all($result)
+    {
+        return $this->rows;
+    }
+}
+
+$GLOBALS['queryCount'] = 0;
+
+$database = new ResearchingCacheHarness();
+$database->rows = [
+    ['id' => 1, 'vref' => 42, 'tech' => 't2', 'timestamp' => 1234],
+];
+
+$first = $database->getResearching(42);
+$second = $database->getResearching(42);
+
+if ($first !== $database->rows || $second !== $database->rows) {
+    fwrite(STDERR, "getResearching() did not return the fetched research rows.\n");
+    exit(1);
+}
+
+if ($GLOBALS['queryCount'] !== 1) {
+    fwrite(
+        STDERR,
+        "Expected one query across two cached reads; got {$GLOBALS['queryCount']}.\n"
+    );
+    exit(1);
+}
+
+fwrite(STDOUT, "getResearching cache regression test passed.\n");


### PR DESCRIPTION
## Summary

This pull request fixes `getResearching()` so database results are stored in the static research cache that the method already reads.

It also adds a focused regression test proving that two reads for the same village execute only one query.

## Problem

`GameEngine/Database/DatabaseTroopQueries.php::getResearching()` starts by checking `self::$researchingCache[$vid]`. After a cache miss, however, it stores the fetched rows in a different, local variable:

```php
$researchingCache[$vid] = $this->mysqli_fetch_all($result);
return $researchingCache[$vid];
```

That local array is discarded when the method returns. A later call for the same village therefore misses the static cache and repeats the same `SELECT`.

This is especially wasteful on pages and automation paths that inspect the same research queue more than once during a request.

## Root cause

The read path and cache-invalidation path both use `self::$researchingCache`, but the population path omitted the `self::` qualifier.

## Solution

The fetched rows are now assigned to and returned from the existing static cache:

```php
self::$researchingCache[$vid] = $this->mysqli_fetch_all($result);
return self::$researchingCache[$vid];
```

The existing cache semantics remain intact:

- `$use_cache = false` still forces a query;
- `addResearch()` still invalidates the cache;
- empty research queues continue to use the method's existing empty-array handling;
- returned row data is unchanged.

## Regression test

`tests/regression/GetResearchingCacheTest.php` uses a minimal trait harness and deterministic `mysqli_query()` stub. It:

1. returns one research row for village 42;
2. calls `getResearching(42)` twice;
3. verifies both calls return the same rows;
4. verifies only one query was executed.

The test would fail against the previous implementation with a query count of two.

## Validation

- `php -l GameEngine/Database/DatabaseTroopQueries.php`
- `php -l tests/regression/GetResearchingCacheTest.php`
- `php tests/regression/GetResearchingCacheTest.php`
- `git diff --check`

## Impact

This is a targeted request-level performance and correctness fix. It changes no schema, query text, public API, or returned data.