### PR TITLE
Clamp expired timers and format durations in constant time

### DIFF
--- a/GameEngine/Generator.php
+++ b/GameEngine/Generator.php
@@ -124,24 +124,12 @@ class MyGenerator
 	 */
 	public function getTimeFormat($time)
 	{
-     $time = (int) $time;
-		$min = 0;
-		$hr = 0;
+		$time = max(0, (int) $time);
+		$hr = intdiv($time, 3600);
+		$min = intdiv($time % 3600, 60);
+		$seconds = $time % 60;
 
-		while ($time >= 60) {
-			$time -= 60;
-			$min++;
-		}
-
-		while ($min >= 60) {
-			$min -= 60;
-			$hr++;
-		}
-
-		if ($min < 10) $min = "0" . $min;
-		if ($time < 10) $time = "0" . $time;
-
-		return $hr . ":" . $min . ":" . $time;
+		return sprintf('%d:%02d:%02d', $hr, $min, $seconds);
 	}
 
 	/**

--- a/tests/regression/GetTimeFormatTest.php
+++ b/tests/regression/GetTimeFormatTest.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once __DIR__ . '/../../GameEngine/Generator.php';
+
+$cases = [
+    -61 => '0:00:00',
+    -1 => '0:00:00',
+    0 => '0:00:00',
+    1 => '0:00:01',
+    59 => '0:00:59',
+    60 => '0:01:00',
+    3599 => '0:59:59',
+    3600 => '1:00:00',
+    86399 => '23:59:59',
+    86400 => '24:00:00',
+    90000 => '25:00:00',
+];
+
+foreach ($cases as $seconds => $expected) {
+    $actual = $generator->getTimeFormat($seconds);
+
+    if ($actual !== $expected) {
+        fwrite(
+            STDERR,
+            "getTimeFormat($seconds): expected $expected, got $actual.\n"
+        );
+        exit(1);
+    }
+}
+
+fwrite(STDOUT, "getTimeFormat regression test passed.\n");


### PR DESCRIPTION
## Summary

This pull request makes `MyGenerator::getTimeFormat()` handle expired timers correctly and calculate durations in constant time.

It:

- clamps negative durations to zero;
- replaces repeated subtraction loops with integer division and modulo;
- preserves unbounded hour values such as `24:00:00` and `25:00:00`;
- adds boundary-focused regression coverage.

## Problem

Many callers format values derived from `endtime - time()`. Once an event has expired, that value can be negative.

The current formatter does not normalize negative input. For example:

```text
-61 => 0:00:0-61
 -5 => 0:00:0-5
```

These malformed values can briefly appear in countdown UI while the request and automation state catch up.

The implementation also calculates minutes and hours through repeated subtraction. Runtime therefore grows with the size of the duration even though the result can be computed directly.

## Root cause

The method assumes non-negative input and pads the still-negative seconds value as if it were a normal value below ten.

## Solution

The formatter now:

1. casts the input to an integer;
2. clamps it with `max(0, ...)`;
3. calculates hours using `intdiv($time, 3600)`;
4. calculates minutes and seconds using modulo;
5. formats the result with `sprintf('%d:%02d:%02d', ...)`.

Hours intentionally remain unbounded instead of wrapping at 24, preserving the method's duration semantics.

## Compatibility

Existing non-negative output remains unchanged:

- `0` → `0:00:00`
- `60` → `0:01:00`
- `3600` → `1:00:00`
- `90000` → `25:00:00`

Only invalid negative output changes, becoming `0:00:00`.

## Validation

- `php -l GameEngine/Generator.php`
- `php -l tests/regression/GetTimeFormatTest.php`
- `php tests/regression/GetTimeFormatTest.php`
- `git diff --check`

The regression table covers negative input, zero, second/minute/hour boundaries, 24 hours, and 25 hours.

## Impact

No database, configuration, or API changes. Expired countdowns now render a valid zero duration, and large durations no longer require linear-time loops.