### PR TITLE
Fix fresh Docker database initialization

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -43,9 +43,13 @@ docker compose up -d
 
 This command will:
 - Build the TravianZ web application container
-- Start a MariaDB (latest) database container
-- Start a phpMyAdmin container for database management
+- Start a MariaDB (latest) database container and wait for it to become ready
+- Start the web application and phpMyAdmin after MariaDB is healthy
 - Set up a network for all containers to communicate
+
+The installation wizard creates the TravianZ schema. SQL files in `var/db`
+are templates whose placeholders are resolved by the installer; MariaDB does
+not execute them directly during container initialization.
 
 ### 4. Access the Installation Wizard
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
     environment:
       - APACHE_DOCUMENT_ROOT=/var/www/html
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     networks:
       - travianz-network
     restart: unless-stopped
@@ -26,13 +27,18 @@ services:
       MARIADB_PASSWORD: ${MARIADB_PASSWORD:-${MYSQL_PASSWORD:-travianzpass}}
     volumes:
       - db-data:/var/lib/mysql
-      - ./var/db:/docker-entrypoint-initdb.d:ro
     ports:
       - "3306:3306"
     networks:
       - travianz-network
     restart: unless-stopped
     command: --sql_mode=""
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest
@@ -45,7 +51,8 @@ services:
     ports:
       - "8081:80"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     networks:
       - travianz-network
     restart: unless-stopped

--- a/tests/docker-compose-contract.sh
+++ b/tests/docker-compose-contract.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+compose_file=${1:-"$repo_root/docker-compose.yml"}
+
+fail()
+{
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+[ -f "$compose_file" ] || fail "Compose file not found: $compose_file"
+
+if awk '
+    /^[[:space:]]*#/ { next }
+    index($0, "./var/db") && index($0, "/docker-entrypoint-initdb.d") { found = 1 }
+    END { exit found ? 0 : 1 }
+' "$compose_file"
+then
+    fail "installer SQL templates must not be mounted into /docker-entrypoint-initdb.d"
+fi
+
+if ! awk '
+    $0 == "  db:" {
+        in_db = 1
+        next
+    }
+    in_db && /^  [[:alnum:]_-]+:$/ {
+        in_db = 0
+    }
+    in_db && $0 == "    healthcheck:" {
+        healthcheck = 1
+    }
+    in_db && /healthcheck[.]sh/ && /--connect/ && /--innodb_initialized/ {
+        readiness_probe = 1
+    }
+    in_db && $0 ~ /^      interval:/ {
+        interval = 1
+    }
+    in_db && $0 ~ /^      timeout:/ {
+        timeout = 1
+    }
+    in_db && $0 ~ /^      retries:/ {
+        retries = 1
+    }
+    END {
+        exit (healthcheck && readiness_probe && interval && timeout && retries) ? 0 : 1
+    }
+' "$compose_file"
+then
+    fail "db service must define a bounded MariaDB readiness healthcheck"
+fi
+
+require_healthy_db_dependency()
+{
+    service=$1
+
+    if ! awk -v service="$service" '
+        $0 == "  " service ":" {
+            in_service = 1
+            next
+        }
+        in_service && /^  [[:alnum:]_-]+:$/ {
+            in_service = 0
+        }
+        in_service && $0 == "    depends_on:" {
+            in_dependencies = 1
+            next
+        }
+        in_service && in_dependencies && $0 == "      db:" {
+            in_db_dependency = 1
+            next
+        }
+        in_service && in_db_dependency && $0 == "        condition: service_healthy" {
+            found = 1
+        }
+        END {
+            exit found ? 0 : 1
+        }
+    ' "$compose_file"
+    then
+        fail "$service must wait for the db service to become healthy"
+    fi
+}
+
+require_healthy_db_dependency web
+require_healthy_db_dependency phpmyadmin
+
+printf 'PASS: Docker Compose database initialization contract\n'


### PR DESCRIPTION
## Summary

This pull request fixes fresh Docker database startup by preventing MariaDB from executing TravianZ's installer SQL templates before their placeholders are resolved.

It also:

- adds the MariaDB image's bounded readiness healthcheck;
- makes the web and phpMyAdmin services wait for a healthy database;
- documents that schema creation belongs to the TravianZ installation wizard;
- adds a zero-dependency Compose contract regression test.

## Problem

The Compose file currently mounts the complete `var/db` directory into MariaDB's automatic initialization directory:

```yaml
- ./var/db:/docker-entrypoint-initdb.d:ro
```

Those files are not ready-to-run database initialization scripts. They are application templates. For example, the first file contains:

```sql
SET @natureRegTime = %NATURE_REG_TIME%;
```

The same directory also contains unresolved placeholders such as `%PREFIX%`, `%VILLAGEID%`, and `%WORLDSIZE%`.

The TravianZ installer normally reads these templates and replaces their placeholders before executing them. Mounting them into `/docker-entrypoint-initdb.d` bypasses that process.

On a fresh data volume, the [official MariaDB entrypoint](https://github.com/MariaDB/mariadb-docker/blob/master/docker-entrypoint.sh#L503-L509) executes every matching file in that directory. MariaDB therefore receives unresolved template syntax before the web installer is opened, which can stop or partially initialize the database container.

## Root cause

Two separate initialization mechanisms were combined:

1. the MariaDB image's automatic raw-SQL initialization;
2. TravianZ's installer-controlled template rendering and schema creation.

Only the second mechanism knows how to resolve TravianZ placeholders.

## Solution

### Leave schema creation to TravianZ

The `./var/db:/docker-entrypoint-initdb.d` mount is removed. MariaDB still creates the configured empty database and application user through its standard environment variables. The existing installation wizard then renders and executes the TravianZ schema exactly as designed.

### Wait for actual database readiness

The database service now uses the healthcheck shipped by the official MariaDB image:

```yaml
healthcheck:
  test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
  interval: 10s
  timeout: 5s
  retries: 10
  start_period: 10s
```

Both `web` and `phpmyadmin` now depend on `db` with `condition: service_healthy`, replacing startup-order-only dependencies.

### Guard the contract

`tests/docker-compose-contract.sh` verifies that:

- the TravianZ SQL template directory is not mounted into MariaDB's init directory;
- the database has a bounded readiness probe;
- the probe checks both connectivity and InnoDB initialization;
- web and phpMyAdmin wait for a healthy database.

The test accepts an optional Compose path so it can also validate fixtures.

## Validation

Completed locally:

- `sh -n tests/docker-compose-contract.sh`
- `sh tests/docker-compose-contract.sh`
- `docker compose config --quiet`
- `git diff --check`

A clean-volume runtime smoke test could not be executed in the review environment because its Docker daemon socket is unavailable. Recommended final acceptance test:

```bash
docker compose down -v
docker compose up -d --build --wait
docker compose logs db
```

Then open `/install/` and complete installation using a non-default table prefix.

## Impact and compatibility

- Existing populated database volumes are unaffected.
- Fresh deployments receive an empty, ready database for the existing wizard.
- No SQL templates, installer queries, credentials, ports, or image versions are changed.
- The readiness probe relies on `healthcheck.sh`, which is provided by the official `mariadb` image currently used by this Compose file.