### PR TITLE
Centralize language loading with English fallback

### DIFF
--- a/Admin/admin.php
+++ b/Admin/admin.php
@@ -38,7 +38,8 @@ include_once("../GameEngine/Admin/csrf.php");
 // ─── CORE INCLUDES ───────────────────────────────────────────────────────────
 include_once("../GameEngine/config.php");
 include_once("../GameEngine/Database.php");
-include_once("../GameEngine/Lang/" . LANG . ".php");
+require_once __DIR__ . "/../GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 include_once("../GameEngine/Admin/database.php");
 
 // Helperul care descopera pachetele grafice din gpack/ (tz_available_gpacks).

--- a/GameEngine/BBCode.php
+++ b/GameEngine/BBCode.php
@@ -21,7 +21,8 @@
 #################################################################################
 
 include_once("config.php");
-include_once("Lang/" . LANG . ".php");
+require_once __DIR__ . "/Lang/loader.php";
+tz_load_language(LANG);
 
 /**
  * Ensure input exists (avoid undefined variable issues)

--- a/GameEngine/Lang/loader.php
+++ b/GameEngine/Lang/loader.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Load one interface language and fill its gaps from English.
+ *
+ * Language files define constants through tz_def(), so loading the selected
+ * locale first preserves translated constants while English defines only the
+ * missing ones. Their legacy $lang arrays need an explicit merge because those
+ * assignments are not guarded.
+ */
+if (!function_exists('tz_language_array_from_file')) {
+    function tz_language_array_from_file($file)
+    {
+        $lang = [];
+        require $file;
+
+        return is_array($lang) ? $lang : [];
+    }
+}
+
+if (!function_exists('tz_load_language')) {
+    function tz_load_language($language, $languageDirectory = __DIR__)
+    {
+        global $lang;
+
+        $language = strtolower(trim((string) $language));
+        if (!preg_match('/\A[a-z_]+\z/', $language)) {
+            $language = 'en';
+        }
+
+        $languageDirectory = rtrim($languageDirectory, '/\\');
+        $englishFile = $languageDirectory . '/en.php';
+        if (!is_file($englishFile)) {
+            throw new RuntimeException('English language fallback not found: ' . $englishFile);
+        }
+
+        $selectedFile = $languageDirectory . '/' . $language . '.php';
+        if (!is_file($selectedFile)) {
+            $selectedFile = $englishFile;
+        }
+
+        $localized = tz_language_array_from_file($selectedFile);
+        if ($selectedFile === $englishFile) {
+            $lang = $localized;
+            return $lang;
+        }
+
+        $english = tz_language_array_from_file($englishFile);
+        $lang = array_replace_recursive($english, $localized);
+
+        return $lang;
+    }
+}

--- a/GameEngine/Session.php
+++ b/GameEngine/Session.php
@@ -60,12 +60,8 @@ include_once("Form.php");
 include_once("Generator.php");
 include_once("Multisort.php");
 include_once("Ranking.php");
-include_once("Lang/" . LANG . ".php");
-// en.php is an idempotent fallback (tz_def only defines missing keys); loading
-// it after the player language guarantees every interface constant is defined,
-// so a key missing from a translation degrades to English instead of a PHP 8.3
-// "undefined constant" fatal (blank page). See issue #189.
-include_once("Lang/en.php");
+require_once __DIR__ . "/Lang/loader.php";
+tz_load_language(LANG);
 include_once("Logging.php");
 include_once("Message.php");
 include_once("Alliance.php");

--- a/Templates/Ajax/mapscroll.tpl
+++ b/Templates/Ajax/mapscroll.tpl
@@ -25,7 +25,8 @@
 ========================= */
 session_start();
 include_once('GameEngine/config.php');
-include_once("GameEngine/Lang/". LANG. ".php");
+require_once dirname(__DIR__, 2) . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 include_once("GameEngine/Generator.php");
 include_once("GameEngine/Database.php");
 

--- a/Templates/Ajax/mapscroll2.tpl
+++ b/Templates/Ajax/mapscroll2.tpl
@@ -25,7 +25,8 @@
 ========================= */
 session_start();
 include_once('GameEngine/config.php');
-include_once("GameEngine/Lang/". LANG. ".php");
+require_once dirname(__DIR__, 2) . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 include_once("GameEngine/Generator.php");
 include_once("GameEngine/Database.php");
 

--- a/anleitung.php
+++ b/anleitung.php
@@ -24,7 +24,8 @@ use App\Utils\AccessLogger;
 
 include_once("GameEngine/config.php");
 include_once("GameEngine/Database.php");
-include_once("GameEngine/Lang/".LANG.".php");
+require_once __DIR__ . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 AccessLogger::logRequest();
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/impressum.php
+++ b/impressum.php
@@ -13,7 +13,8 @@ use App\Utils\AccessLogger;
 
 include_once("GameEngine/config.php");
 include_once("GameEngine/Database.php");
-include_once("GameEngine/Lang/".LANG.".php");
+require_once __DIR__ . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 
 AccessLogger::logRequest();
 ?>

--- a/index.php
+++ b/index.php
@@ -50,7 +50,8 @@ else
 }
 
 include_once "GameEngine/Database.php";
-include_once "GameEngine/Lang/".LANG.".php";
+require_once __DIR__ . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 
 AccessLogger::logRequest();
 ?>

--- a/install/include/accounts.php
+++ b/install/include/accounts.php
@@ -35,7 +35,8 @@
 		include_once($configFile);
 		include_once("../../GameEngine/Database.php");
 		include_once("../../GameEngine/Admin/database.php");
-		include_once("../../GameEngine/Lang/" . LANG . ".php");
+		require_once dirname(__DIR__, 2) . "/GameEngine/Lang/loader.php";
+		tz_load_language(LANG);
 
 		// update Admin details first
 		$gameConfig = file_get_contents($configFile);

--- a/manual.php
+++ b/manual.php
@@ -22,14 +22,8 @@
 #################################################################################
 
 include_once("GameEngine/config.php");
-// Load the interface language for the manual templates. Since #186 these
-// templates use translation constants (OVERVIEW, TRIBE1, ...) instead of
-// hardcoded English; without a language file every constant would be
-// undefined and PHP 8.3 would fatal, leaving the in-game help iframe blank.
-// en.php is loaded last as an idempotent fallback (tz_def) to fill any key
-// missing from the active language.
-include_once("GameEngine/Lang/" . LANG . ".php");
-include_once("GameEngine/Lang/en.php");
+require_once __DIR__ . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 ?>
 
 <html>

--- a/notification/index.php
+++ b/notification/index.php
@@ -17,8 +17,9 @@
 #################################################################################
 
 include("../GameEngine/config.php");
-include("../GameEngine/Lang/".LANG.".php");
-include("lang/".LANG.".php");
+require_once dirname(__DIR__) . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
+include(__DIR__ . "/lang/".LANG.".php");
 if(T4_COMING==true){
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/password.php
+++ b/password.php
@@ -28,7 +28,8 @@ if (!file_exists('var/installed') && @opendir('install')) {
 }
 
 include_once("GameEngine/config.php");
-include_once("GameEngine/Lang/" . LANG . ".php");
+require_once __DIR__ . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 include_once("GameEngine/Database.php");
 include_once("GameEngine/Mailer.php");
 include_once("GameEngine/Generator.php");

--- a/spielregeln.php
+++ b/spielregeln.php
@@ -17,7 +17,8 @@ use App\Utils\AccessLogger;
 
 include_once("GameEngine/config.php");
 include_once("GameEngine/Database.php");
-include_once("GameEngine/Lang/".LANG.".php");
+require_once __DIR__ . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 AccessLogger::logRequest();
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/terms.php
+++ b/terms.php
@@ -24,7 +24,8 @@ use App\Utils\AccessLogger;
 
 include_once("GameEngine/config.php");
 include_once("GameEngine/Database.php");
-include_once("GameEngine/Lang/".LANG.".php");
+require_once __DIR__ . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 
 AccessLogger::logRequest();
 ?>

--- a/tests/LanguageLoaderTest.php
+++ b/tests/LanguageLoaderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
+
+function fail_test($message)
+{
+    throw new RuntimeException($message);
+}
+
+function assert_same($expected, $actual, $message)
+{
+    if ($expected !== $actual) {
+        fail_test(
+            $message
+            . "\nExpected: " . var_export($expected, true)
+            . "\nActual:   " . var_export($actual, true)
+        );
+    }
+}
+
+function run_language_case($language)
+{
+    $expected = [
+        'en' => [
+            'tribe' => 'Romans',
+            'welcome' => 'Welcome to Test Server',
+        ],
+        'fr' => [
+            'tribe' => 'Romains',
+            'welcome' => 'Bienvenue sur le Test Server!',
+        ],
+        'it' => [
+            'tribe' => 'Romani',
+            'welcome' => 'Benvenuto in Test Server',
+            'fallback' => ['TRIBE7', 'Egyptians'],
+        ],
+        'ro' => [
+            'tribe' => 'Romani',
+            'welcome' => 'Bine ai venit pe Test Server',
+            'fallback' => ['PUBLIC_WELCOME_TO', 'Welcome to'],
+        ],
+        'zh' => [
+            'tribe' => '罗马',
+            'welcome' => '欢迎来到 Test Server',
+            'fallback' => ['TRIBE7', 'Egyptians'],
+        ],
+    ];
+
+    if (!isset($expected[$language])) {
+        fail_test('Unknown test language: ' . $language);
+    }
+
+    define('SERVER_NAME', 'Test Server');
+    define('USRNM_MIN_LENGTH', 3);
+    define('PW_MIN_LENGTH', 6);
+    define('COMMENCE', 0);
+    define('TS_THRESHOLD', 0);
+    define('CRANNY_CAPACITY', 100);
+    define('SPEED', 1);
+
+    require dirname(__DIR__) . '/GameEngine/Lang/loader.php';
+    $loaded = tz_load_language($language);
+
+    assert_same($expected[$language]['tribe'], TRIBE1, $language . ': selected constants must win');
+    assert_same(
+        $expected[$language]['welcome'],
+        $loaded['index'][0][1] ?? null,
+        $language . ': selected $lang values must survive the English fallback'
+    );
+    assert_same($loaded, $GLOBALS['lang'], $language . ': loader must publish the merged global array');
+
+    if (isset($expected[$language]['fallback'])) {
+        [$constant, $value] = $expected[$language]['fallback'];
+        assert_same($value, constant($constant), $language . ': missing constant must fall back to English');
+    }
+
+    $fixtureDirectory = __DIR__ . '/fixtures/languages';
+    $fixture = tz_load_language('xx', $fixtureDirectory);
+    assert_same(
+        'English fallback',
+        $fixture['nested']['fallback_only'] ?? null,
+        $language . ': missing nested array value must fall back to English'
+    );
+    assert_same(
+        'Localized shared',
+        $fixture['nested']['shared'] ?? null,
+        $language . ': localized nested array value must override English'
+    );
+    assert_same(
+        'Localized value',
+        $fixture['nested']['localized_only'] ?? null,
+        $language . ': localized-only nested array value must be preserved'
+    );
+    assert_same(
+        'English fallback',
+        LANGUAGE_LOADER_FIXTURE_FALLBACK,
+        $language . ': fixture constant must fall back to English'
+    );
+    assert_same(
+        'Localized value',
+        LANGUAGE_LOADER_FIXTURE_LOCALIZED,
+        $language . ': fixture localized constant must win'
+    );
+
+    $invalid = tz_load_language('../xx', $fixtureDirectory);
+    assert_same(
+        'English shared',
+        $invalid['nested']['shared'] ?? null,
+        $language . ': invalid locale must use English'
+    );
+
+    echo "PASS {$language}\n";
+}
+
+if (isset($argv[1])) {
+    run_language_case($argv[1]);
+    exit(0);
+}
+
+$languages = ['en', 'fr', 'it', 'ro', 'zh'];
+foreach ($languages as $language) {
+    $pipes = [];
+    $process = proc_open(
+        [PHP_BINARY, __FILE__, $language],
+        [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ],
+        $pipes,
+        __DIR__
+    );
+
+    if (!is_resource($process)) {
+        fail_test('Unable to start test process for ' . $language);
+    }
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $status = proc_close($process);
+
+    if ($status !== 0) {
+        fwrite(STDERR, $stderr !== '' ? $stderr : $stdout);
+        exit($status);
+    }
+
+    echo $stdout;
+}
+
+echo "PASS language loader: 5 locales\n";

--- a/tests/fixtures/languages/en.php
+++ b/tests/fixtures/languages/en.php
@@ -1,0 +1,6 @@
+<?php
+
+tz_def('LANGUAGE_LOADER_FIXTURE_FALLBACK', 'English fallback');
+
+$lang['nested']['fallback_only'] = 'English fallback';
+$lang['nested']['shared'] = 'English shared';

--- a/tests/fixtures/languages/xx.php
+++ b/tests/fixtures/languages/xx.php
@@ -1,0 +1,6 @@
+<?php
+
+tz_def('LANGUAGE_LOADER_FIXTURE_LOCALIZED', 'Localized value');
+
+$lang['nested']['localized_only'] = 'Localized value';
+$lang['nested']['shared'] = 'Localized shared';

--- a/tutorial.php
+++ b/tutorial.php
@@ -24,7 +24,8 @@ use App\Utils\AccessLogger;
 
 include_once("GameEngine/config.php");
 include_once("GameEngine/Database.php");
-include_once("GameEngine/Lang/".LANG.".php");
+require_once __DIR__ . "/GameEngine/Lang/loader.php";
+tz_load_language(LANG);
 AccessLogger::logRequest();
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">


### PR DESCRIPTION
## Summary

This pull request centralizes TravianZ language loading and guarantees an English fallback anywhere an interface locale is loaded directly.

It:

- keeps the selected translation authoritative;
- fills missing constants from English;
- fills missing nested `$lang` array values from English without overwriting localized values;
- applies the same behavior across public pages, game bootstrap, admin, installer, notification, BBCode, and Ajax map entrypoints;
- adds zero-dependency regression coverage for every supported locale.

## Problem

TravianZ currently has two different language-loading behaviors.

The main game session loads the selected locale and then English, but several standalone entrypoints load only:

```php
include_once("GameEngine/Lang/" . LANG . ".php");
```

This includes the homepage, password recovery, tutorial, instructions, terms, imprint, game rules, admin, and Ajax entrypoints.

The translation files are not equally complete. Under PHP 8, referencing a missing constant is a fatal error rather than a recoverable notice, so a valid configured locale can leave a standalone page blank even though English contains the required key.

There is a second, subtler issue: language constants use the guarded `tz_def()` helper, but legacy homepage strings are stored in a mutable nested `$lang` array. Simply including English after the selected locale preserves constants, but English array assignments can overwrite localized array values.

## Root cause

Fallback behavior is implemented through ad-hoc include order at individual entrypoints. That works differently for immutable guarded constants and mutable arrays, and many entrypoints omit the fallback entirely.

## Solution

### Shared loader

`GameEngine/Lang/loader.php` now owns the contract:

1. normalize and validate the requested locale;
2. fall back to the English file when the locale is invalid or unavailable;
3. load the selected locale first so its `tz_def()` constants win;
4. load English second so only missing constants are defined;
5. capture each file's `$lang` array separately;
6. merge arrays with English as the base and the selected locale as the override;
7. publish the merged array through the existing global `$lang` variable.

```php
$lang = array_replace_recursive($english, $localized);
```

This preserves translated nested values while filling only gaps.

The loader fails clearly if the required English fallback file itself is missing.

### Consistent entrypoints

Direct language includes were replaced with the shared loader in 15 locations covering:

- public and static pages;
- `GameEngine/Session.php`;
- admin and installer flows;
- BBCode and manual rendering;
- Ajax map endpoints;
- notification bootstrap.

The notification module's own separate notification-language pack still loads exactly as before. `GameEngine/Technology.php` remains intentionally English-only during installer bootstrap.

## Regression coverage

`tests/LanguageLoaderTest.php` runs each real locale in a separate PHP process because constants cannot be reset within one process.

For `en`, `fr`, `it`, `ro`, and `zh`, it verifies:

- selected constants remain localized;
- selected homepage array values remain localized;
- missing constants fall back to English;
- the merged array is published globally.

Small incomplete-language fixtures additionally verify:

- English-only nested values are retained;
- localized shared values override English;
- localized-only values survive;
- missing and invalid locale names fall back safely.

## Validation

- `php tests/LanguageLoaderTest.php`
  - all five supported locales passed
- Full syntax sweep
  - 1,097 tracked PHP/template files passed
  - the intentionally tokenized `install/data/constant_format.tpl` generator was excluded
- Changed-file syntax checks
- `git diff --check`

## Compatibility and impact

- No translations or language constants are renamed.
- No database, configuration, route, or template output contract changes.
- Complete locales render as before.
- Incomplete locales now use English only for missing values instead of failing.
- Existing localized `$lang` values are no longer overwritten by fallback loading.