### PR TITLE
fix(combat): keep the hero casualty when rams force a battle recalculation [#372]

### DIFF
--- a/GameEngine/Automation/AutomationBattleResolution.php
+++ b/GameEngine/Automation/AutomationBattleResolution.php
@@ -1477,7 +1477,8 @@ trait AutomationBattleResolution {
      * @param int    $walllevel  Current wall level.
      * @param int    $wallid     Wall building field id (40).
      * @param int    $ram_pic    Ram unit id (for the report fragment).
-     * @param array  $battlepart Battle result (provides the ram damage factors).
+     * @param array  $battlepart Battle result (provides the ram damage factors,
+     *                           and the hero verdict carried over to the recalculation).
      * @param array  $ctx        Battle context for the post-damage recalculation
      *                           (Attacker, Defender, tribes, populations, AB tech, ...).
      * @return array { battlepart: array (possibly recalculated), info_ram: string }
@@ -1510,7 +1511,12 @@ trait AutomationBattleResolution {
             //If the wall got damaged/destroyed during the attack
             //we need to recalculate the whole battle
             if($newLevel != $walllevel){
-                $battlepart = $battle->calculateBattle($ctx['Attacker'], $ctx['Defender'], $newLevel, $ctx['att_tribe'], $ctx['def_tribe'], $ctx['residence'], $ctx['attpop'], $ctx['defpop'], $ctx['type'], $ctx['def_ab'], $ctx['att_ab1'], $ctx['att_ab2'], $ctx['att_ab3'], $ctx['att_ab4'], $ctx['att_ab5'], $ctx['att_ab6'], $ctx['att_ab7'], $ctx['att_ab8'], $ctx['tblevel'], $ctx['stonemason'], $newLevel, 0, 0, 0, $ctx['AttackerID'], $ctx['DefenderID'], $ctx['AttackerWref'], $ctx['DefenderWref'], $ctx['conqureby'], $ctx['enforcementarray']);
+                // The heroes already took their damage during the first pass and
+                // it was written to the hero table, so the recalculation must not
+                // apply it again: it would look up living heroes only, miss the
+                // one who just died and drop him from the report (issue #372).
+                // The first verdict is handed over instead.
+                $battlepart = $battle->calculateBattle($ctx['Attacker'], $ctx['Defender'], $newLevel, $ctx['att_tribe'], $ctx['def_tribe'], $ctx['residence'], $ctx['attpop'], $ctx['defpop'], $ctx['type'], $ctx['def_ab'], $ctx['att_ab1'], $ctx['att_ab2'], $ctx['att_ab3'], $ctx['att_ab4'], $ctx['att_ab5'], $ctx['att_ab6'], $ctx['att_ab7'], $ctx['att_ab8'], $ctx['tblevel'], $ctx['stonemason'], $newLevel, 0, 0, 0, $ctx['AttackerID'], $ctx['DefenderID'], $ctx['AttackerWref'], $ctx['DefenderWref'], $ctx['conqureby'], $ctx['enforcementarray'], $battlepart);
             }
         }
 

--- a/GameEngine/Battle.php
+++ b/GameEngine/Battle.php
@@ -484,6 +484,13 @@ class Battle {
 	Function to process Calculate Battle
 	(Phase 2: orchestrator — fiecare sectiune
 	a devenit un helper privat, mai jos)
+
+	$previousHeroOutcome: result of an earlier
+	pass over the SAME battle (rams changed the
+	wall level, so it is replayed). When set,
+	the hero damage is not applied a second
+	time — the first verdict is reused instead
+	(issue #372).
 	*****************************************/
 
 	function calculateBattle(
@@ -498,8 +505,9 @@ class Battle {
 		$AttackerID, $DefenderID,
 		$AttackerWref, $DefenderWref,
 		$conqureby,
-		$defReinforcements = null) {
-			
+		$defReinforcements = null,
+		$previousHeroOutcome = null) {
+
     global $database, $unitsbytype;
 
     /******************************************************************
@@ -693,27 +701,43 @@ class Battle {
     );
 
     /******************************************************************
-     * HERO DAMAGE (ATTACKER)
-     ******************************************************************/
-    /**
-     * URMARIRE TEMPORARA - se poate sterge dupa ce gasim cauza.
+     * HERO DAMAGE — carry over on a recalculation
      *
-     * Scrie in error_log de ce (nu) moare eroul. Doar cand atacatorul chiar a
-     * trimis un erou, ca sa nu umple logul.
-     */
-    if (!empty($Attacker['uhero'])) {
-        error_log(sprintf(
-            '[TravianZ][EROU] uid=%s heroid=%s health=%s | attUnits[hero]=%s | intra_in_bloc=%s | lossRatio=%s',
-            isset($AttackerID) ? $AttackerID : '?',
-            isset($atkhero['heroid']) ? $atkhero['heroid'] : 'NULL',
-            isset($atkhero['health']) ? $atkhero['health'] : 'NULL',
-            isset($units['Att_unit']['hero']) ? $units['Att_unit']['hero'] : 'NESETAT',
-            (!empty($units['Att_unit']['hero']) && !empty($atkhero['heroid'])) ? 'DA' : 'NU',
-            isset($result[1]) ? $result[1] : '?'
-        ));
+     * applyHeroBattleDamage() WRITES to the hero table, so it must run
+     * exactly once per battle. When rams change the wall level, the caller
+     * replays the whole battle (AutomationBattleResolution::applyRamDamage()).
+     * On that second pass the "WHERE dead = 0" lookup no longer finds a hero
+     * who just died on the first pass: applyHeroBattleDamage() returns null
+     * and the hero casualty silently disappears from the result. The hero was
+     * then dead in the hero table but reported alive, t11 was never
+     * decremented and returnunitsComplete() put him back in the village
+     * (issue #372). Defender heroes were also charged their health damage
+     * twice.
+     *
+     * The caller passes the first pass result in $previousHeroOutcome so the
+     * verdict is carried over instead of being recomputed.
+     ******************************************************************/
+    $heroDamageAlreadyApplied = ($previousHeroOutcome !== null);
+
+    if ($heroDamageAlreadyApplied) {
+
+        if (isset($previousHeroOutcome['casualties_attacker'][11])) {
+            $result['casualties_attacker'][11] = $previousHeroOutcome['casualties_attacker'][11];
+        }
+
+        if (isset($previousHeroOutcome['deadherodef'])) {
+            $result['deadherodef'] = $previousHeroOutcome['deadherodef'];
+        }
+
+        if (isset($previousHeroOutcome['deadheroref'])) {
+            $result['deadheroref'] = $previousHeroOutcome['deadheroref'];
+        }
     }
 
-    if (!empty($units['Att_unit']['hero']) && !empty($atkhero['heroid'])) {
+    /******************************************************************
+     * HERO DAMAGE (ATTACKER)
+     ******************************************************************/
+    if (!$heroDamageAlreadyApplied && !empty($units['Att_unit']['hero']) && !empty($atkhero['heroid'])) {
 
         /**
          * A fost armata NIMICITA?
@@ -752,11 +776,6 @@ class Battle {
             $armyWipedOut
         );
 
-        error_log(sprintf(
-            '[TravianZ][EROU] trimise=%d pierdute=%d armata_nimicita=%s | applyHeroBattleDamage=%s',
-            $sentTotal, $deadTotal, $armyWipedOut ? 'DA' : 'nu', var_export($dead, true)
-        ));
-
         if ($dead === 1) {
             $result['casualties_attacker'][11] = 1;
         }
@@ -765,7 +784,7 @@ class Battle {
     /******************************************************************
      * HERO DAMAGE (DEFENDER)
      ******************************************************************/
-    if (!empty($units['Def_unit']['hero']) && !empty($defenderhero['heroid'])) {
+    if (!$heroDamageAlreadyApplied && !empty($units['Def_unit']['hero']) && !empty($defenderhero['heroid'])) {
 
         $dead = $this->applyHeroBattleDamage($defenderhero['heroid'], $result[2]);
 
@@ -777,7 +796,7 @@ class Battle {
     /******************************************************************
      * HERO DAMAGE (DEFENDER + REINFORCEMENTS)
      ******************************************************************/
-    if (!empty($DefendersAll)) {
+    if (!$heroDamageAlreadyApplied && !empty($DefendersAll)) {
 
         $battleHeroesCache = [];
         $villageOwnerCache = [];

--- a/Templates/Build/37_revive.tpl
+++ b/Templates/Build/37_revive.tpl
@@ -184,8 +184,13 @@ foreach ($heroes as $hero_datarow) {
             </tr>
     </table>
 		<?php
-	} elseif (!$reviving) {
+	} elseif (!$reviving && $hero_datarow['dead'] == 1) {
 		/**
+		 * Only a DEAD hero gets a revive row: $heroes holds every hero row of
+		 * the player, so without this guard a hero who is merely in training
+		 * was offered for revival as well (the action below is already gated
+		 * on dead == 1, so the button did nothing).
+		 *
 		 * BUG REPARAT: invierea cerea ca unitatea EROULUI sa fie cercetata in
 		 * satul CURENT.
 		 *


### PR DESCRIPTION
## Why it was broken

When rams change the wall level, `applyRamDamage()` recalculates the whole battle, so `calculateBattle()` runs a second time. But `calculateBattle()` is not pure: it kills the hero in the database, and `applyHeroBattleDamage()` only looks for a hero with `dead = 0`.

- **First run:** the hero dies, `hero.dead = 1` is written, and he is flagged as a casualty. This result is then thrown away.
- **Second run:** the hero is not found any more, because he is already dead. The function returns `null`, so the casualty flag is missing from the result that is actually used.

Everything after that believes the hero survived: the report says "your hero gained X XP" instead of "your hero died", `t11` is never decremented, and when the troops come home the hero is added back to `units.hero`. That is why he stays visible in dorf1 and in the rally point although he is dead in the database.

It only happens when rams change the wall level, which is the case in every screenshot of the issue. The same attack without rams was already correct.

Defending heroes had the opposite symptom: their health was subtracted twice for one battle.

## The patch

`calculateBattle()` takes a new optional last parameter `$previousHeroOutcome`. When `applyRamDamage()` recalculates the battle it passes the result of the first run, and the hero part is not redone: the first verdict is reused. The hero damage is applied, and written to the database, exactly once per battle again.

- `GameEngine/Battle.php`: the new parameter and the reuse of the first verdict. Also removes the temporary `[TravianZ][EROU]` debug logs.
- `GameEngine/Automation/AutomationBattleResolution.php`: `applyRamDamage()` passes the first result to the recalculation.
- `Templates/Build/37_revive.tpl`: the revive row is rendered only for a hero that is really dead. Since the research condition was dropped in 6980a9ac, a hero in training was offered for revival too.

Without rams, or when the wall level does not change, the code path is unchanged.

## Testing

Tested in game: attack with rams and hero, army wiped out. The hero is reported as dead, disappears from dorf1 and from the rally point, and can be revived in the village he attacked from. `scripts/check.sh` is green.

Please test before merging, I could not reproduce every case:

- [ ] hero dying as a defender
- [ ] hero sitting in reinforcements
- [ ] oasis attack
- [ ] hero surviving while the wall is destroyed (his health should now drop once instead of twice)