### PR TITLE
fix distance calculation when adding new raid in farmlist

### DIFF
--- a/Templates/goldClub/farmlist_addraid.tpl
+++ b/Templates/goldClub/farmlist_addraid.tpl
@@ -102,7 +102,7 @@ if ($action === 'addSlot' && $lid) {
             /* ======================
                FINAL INSERT
             ====================== */
-            $coor = $database->getCoor($village->wid);
+            $coor = $database->getCoor($FLData['wref']);
             $distance = $database->getDistance($coor['x'], $coor['y'], $WrefX, $WrefY);
 
             $database->addSlotFarm(


### PR DESCRIPTION
When adding a raid to the farmlist the distance is stored in the raidlist table. However this distance is calculated based on the current selected village instead of the village the farmlist belongs to.