### PR TITLE
Fix(combat): stop the dead hero being removed twice from the troop count [#379]

### DIFF
--- a/GameEngine/Automation/AutomationBattleResolution.php
+++ b/GameEngine/Automation/AutomationBattleResolution.php
@@ -1231,9 +1231,24 @@ trait AutomationBattleResolution {
         if ($unitlist) {
             $owndead['hero'] = (isset($battlepart['deadherodef']) ? $battlepart['deadherodef'] : '');
 
-            $unitModifications_units[] = 'hero';
-            $unitModifications_amounts[] = $owndead['hero'];
-            $unitModifications_modes[] = 0;
+            /**
+             * BUG FIXED (issue #379): units.hero ended up at -1.
+             *
+             * The value is still reported (it feeds the battle report and the
+             * points), but it must NOT be subtracted from units.hero here any
+             * more. Battle::applyHeroBattleDamage() already clears the column
+             * itself ("UPDATE units u JOIN vdata v SET u.hero = 0 WHERE
+             * v.owner = <hero owner>") the moment the hero dies, and that runs
+             * inside calculateBattle(), i.e. BEFORE this method.
+             *
+             * So the column went 1 -> 0 there and 0 - 1 -> -1 here: the
+             * village kept showing "-1 Hero" in the troop list while the
+             * Hero's Mansion correctly offered a revive.
+             *
+             * One writer only: the death is owned by applyHeroBattleDamage(),
+             * which is also the only place that knows about the hero's other
+             * possible locations (reinforcements, another village).
+             */
         }
 
         // modify units in DB
@@ -1330,10 +1345,21 @@ trait AutomationBattleResolution {
             }
 
             if ($enforce['hero'] > 0) {
-                $enforceModificationsById[$enforce['id']]['units'][] = 'hero';
-                $enforceModificationsById[$enforce['id']]['amounts'][] = $battlepart['deadheroref'][$enforce['id']];
-                $enforceModificationsById[$enforce['id']]['modes'][] = 0;
-
+                /**
+                 * BUG FIXED (issue #379), same double subtraction as in
+                 * applyOwnDefenceCasualties(): a reinforcement hero who died
+                 * was already removed by Battle::applyHeroBattleDamage()
+                 * ("UPDATE enforcement e JOIN vdata v SET e.hero = 0"), so
+                 * subtracting him again here drove enforcement.hero to -1.
+                 *
+                 * $enforce still reads 1 because getEnforceVillage() answers
+                 * from the request cache filled before the battle, so the
+                 * stale row hid the problem instead of preventing it.
+                 *
+                 * The dead count below is kept: it is what the reinforcement
+                 * report and $wrong (which decides whether the wiped-out
+                 * reinforcement row is deleted) are built from.
+                 */
                 $dead['hero'] = $battlepart['deadheroref'][$enforce['id']];
                 $alldead['hero'] += $dead['hero'];
                 $wrong = $dead['hero'] != $enforce['hero'];

--- a/GameEngine/Database/DatabaseTroopQueries.php
+++ b/GameEngine/Database/DatabaseTroopQueries.php
@@ -614,7 +614,25 @@ trait DatabaseTroopQueries {
             //Fixed part of negative troops (double troops) - by InCube
             $array_amt[$i] = (int) $array_amt[$i] < 0 ? 0 : $array_amt[$i];
             //Fixed part of negative troops (double troops) - by InCube
-            $units .= $unit.' = '.$unit.' '.(($array_mode[$i] == 1)? '+':'-').'  '.($array_amt[$i] ? $array_amt[$i] : 0).(($number > $i+1) ? ', ' : '');
+            $amount = (int) ($array_amt[$i] ? $array_amt[$i] : 0);
+
+            /**
+             * The guard above only clamps the AMOUNT, never the RESULT, so any
+             * caller subtracting more than the column holds wrote a NEGATIVE
+             * troop count (issue #379: "-1 Hero" in the village troop list,
+             * after the hero was removed once by Battle::applyHeroBattleDamage()
+             * and a second time by the casualty pipeline).
+             *
+             * A negative troop count is never a valid game state, so floor the
+             * subtraction at 0 in SQL. Additions are untouched.
+             */
+            if ($array_mode[$i] == 1) {
+                $units .= $unit.' = '.$unit.' + '.$amount;
+            } else {
+                $units .= $unit.' = GREATEST('.$unit.' - '.$amount.', 0)';
+            }
+
+            $units .= (($number > $i+1) ? ', ' : '');
 		}
 		$q = "UPDATE ".TB_PREFIX."units set $units WHERE vref = $vref";
 		return mysqli_query($this->dblink, $q);
@@ -881,7 +899,14 @@ trait DatabaseTroopQueries {
 
         foreach ($unit as $index => $unitType) {
             $unitType = ($unitType != 'hero' ? 'u' . $this->escape($unitType) : $unitType);
-		    $pairs[] = $unitType . ' = ' . $unitType . (!(int) $mode[$index] ? ' - ' : ' + ') . (int) $amt[$index];
+
+            // Same floor as modifyUnit(): a reinforcement column must never go
+            // negative either (issue #379).
+            if ((int) $mode[$index]) {
+                $pairs[] = $unitType . ' = ' . $unitType . ' + ' . (int) $amt[$index];
+            } else {
+                $pairs[] = $unitType . ' = GREATEST(' . $unitType . ' - ' . (int) $amt[$index] . ', 0)';
+            }
         }
 
 		$q = "UPDATE " . TB_PREFIX . "enforcement SET ".implode(', ', $pairs)." WHERE id = $id";


### PR DESCRIPTION
Fixes #379

## Symptom

After a battle in which the defending hero dies, the village troop
list shows "-1 Hero". The Hero's Mansion correctly offers a revive at
the same time, so the two screens contradict each other.

It is not a display glitch: units.hero really holds -1. The column is
int(11) signed, so a negative value is stored without any error.

## Cause: the dead hero is removed twice

1. Battle::applyHeroBattleDamage() clears the hero as soon as he dies
   (GameEngine/Battle.php:1816):

       UPDATE units u JOIN vdata v ON v.wref = u.vref
          SET u.hero = 0
        WHERE v.owner = <hero owner> AND u.hero > 0

   The column goes 1 -> 0. This was added in 3b305d85 ("fix hero").

2. Later in the same tick, the casualty pipeline subtracts him again.
   AutomationBattleResolution::applyOwnDefenceCasualties() pushes
   'hero' into the modifyUnit() arrays with deadherodef = 1
   (AutomationBattleResolution.php:1234), so the column goes
   0 - 1 -> -1.

The order is not ambiguous: calculateBattle() runs at line 2644 and
applyOwnDefenceCasualties() at line 2722 of the same method, so step 1
always happens before step 2.

modifyUnit() does not protect against this. The existing InCube guard
(DatabaseTroopQueries.php:614) clamps the AMOUNT that is subtracted,
never the RESULT.

The same double subtraction exists for reinforcement heroes:
applyHeroBattleDamage() also runs "SET e.hero = 0"
(GameEngine/Battle.php:1822) and applyReinforcementCasualties() then
subtracts the hero again (AutomationBattleResolution.php:1333),
driving enforcement.hero to -1. That path is easy to miss because
$enforce['hero'] still reads 1 there: getEnforceVillage() answers from
the request cache that was filled before the battle, so the stale row
hides the state on disk.

## Fix

One writer only. The death is owned by applyHeroBattleDamage(), which
is also the only place that knows about the hero's other possible
locations (a reinforcement sent to someone else, another village).

applyOwnDefenceCasualties() and applyReinforcementCasualties() keep
COMPUTING the dead-hero count, because it is still needed for:

* the battle report (deadhero / DefenderHeroesDeadArray),
* the attacker's points (owndead['hero'] * 6),
* the $wrong flag, which decides whether a wiped-out reinforcement row
  is deleted.

They just no longer WRITE it.

As defence in depth, modifyUnit() and modifyEnforce() now floor every
subtraction at 0 in SQL:

    u1 = GREATEST(u1 - 5, 0)

instead of

    u1 = u1 - 5

Additions are untouched. A negative troop count is never a valid game
state, so no caller can store one again, whatever the accounting bug.

## Repairing existing data

The code fix does not clean values that were already written. Servers
that have been running since 3b305d85 need this once:

    UPDATE PREFIX_units       SET hero = 0 WHERE hero < 0;
    UPDATE PREFIX_enforcement SET hero = 0 WHERE hero < 0;

Replace PREFIX with your TB_PREFIX. Nothing else is needed: hero.dead
is already correct, so the revive works normally once the column is
back to 0.

## Verification

php -l is clean on both files.

The SQL fragment built by modifyUnit() was compared old vs new on a
harness covering subtractions, additions, the 99/99o trapped-unit
columns, the 230/231/120/121 remapping, and empty/negative amounts.
The generated SQL is equivalent for every valid input; it differs only
in the pathological case, which is exactly the one being fixed.

In game, the cases to exercise are:

* hero killed while defending his own village: the troop list must
  show no hero at all rather than -1, and the Mansion must offer the
  revive,
* revive it and check the hero comes back at 1,
* hero killed while reinforcing another player: enforcement.hero must
  reach 0, and the reinforcement report must still mention the dead
  hero,
* an ordinary battle with no hero involved, to confirm the GREATEST()
  change did not alter normal troop losses.

That last one matters because modifyUnit() is on the hot path of every
troop movement, not just of hero deaths.