### PR TITLE
Fix orphaned oases after village destruction

### DIFF
--- a/GameEngine/Database/DatabaseVillageQueries.php
+++ b/GameEngine/Database/DatabaseVillageQueries.php
@@ -557,13 +557,16 @@ trait DatabaseVillageQueries {
 	 */
 	
 	function removeOases($wref, $mode = 0) {
-	    list($wref) = $this->escape_input((int) $wref);
-
-	    if(!is_array($wref)) $wref = [$wref];
+	    if(!is_array($wref)) {
+	        $wref = [$wref];
+	    }
+	
+	    $wref = array_map('intval', $wref);
 	    $wrefs = implode(",", $wref);
-	    
-		$q = "UPDATE ".TB_PREFIX."odata SET conqured = 0, owner = 2, name = 'Unoccupied Oasis' WHERE ".(!$mode ? "wref IN($wrefs)" : "conqured IN($wrefs)");
-		return mysqli_query($this->dblink,$q);
+	
+	    $q = "UPDATE ".TB_PREFIX."odata SET conqured = 0, owner = 2, name = 'Unoccupied Oasis' WHERE ".(!$mode ? "wref IN($wrefs)" : "conqured IN($wrefs)");
+	
+	    return mysqli_query($this->dblink,$q);
 	}
 
 	/***************************


### PR DESCRIPTION
Fixes #385

## Problem

When a village is completely destroyed, its conquered oases are supposed to be released.

`DelVillage()` already calls:

```php
$this->removeOases($wref, 1);
```

However, `DelVillage()` converts `$wref` into an array before calling `removeOases()`.

Inside `removeOases()`, the value is currently cast directly to an integer:

```php
list($wref) = $this->escape_input((int) $wref);
```

When `$wref` is a non-empty array, PHP converts it to integer `1`.

For example:

```text
DelVillage(12345)
→ $wref = [12345]
→ removeOases([12345], 1)
→ (int) [12345]
→ 1
```

This causes the query to effectively look for:

```sql
WHERE conqured IN (1)
```

instead of:

```sql
WHERE conqured IN (12345)
```

As a result, the village is deleted but its oases remain assigned to the player and still reference the deleted village.

## Fix

Normalize `$wref` into an array first and cast each individual ID using `intval()`:

```php
if(!is_array($wref)) {
    $wref = [$wref];
}

$wref = array_map('intval', $wref);
$wrefs = implode(",", $wref);
```

This preserves support for both single IDs and arrays while ensuring the correct village IDs are used when releasing oases.