### PR TITLE
Add integrated global in-game chat

### DIFF
--- a/Templates/natars.tpl
+++ b/Templates/natars.tpl
@@ -2,7 +2,7 @@
 #################################################################################
 ##              -= YOU MAY NOT REMOVE OR CHANGE THIS NOTICE =-                 ##
 ## --------------------------------------------------------------------------- ##
-##  Filename       natars.tpl                                                  ##
+##  Filename       : natars.tpl                                                ##
 ##  Original Code  TravianZ Project                                            ##
 ##  Refactored by: Shadow Incremental Refactor 			                       ##
 ##  License:       TravianZ Project                                            ##
@@ -15,7 +15,6 @@
 ##  - Reduced magic numbers                                                    ##
 ##  - Added safer variable handling                                            ##
 ##  - Added comments                                                           ##
-##                                                                             ##
 #################################################################################
 
 /**
@@ -92,3 +91,20 @@ foreach ($spawnEvents as $eventName => $spawnTime) {
     }
 }
 ?>
+
+<!-- TravianZ Global Chat -->
+<script type="text/javascript">
+(function () {
+    var src = '<?php echo (defined("GP_LOCATE") ? GP_LOCATE : ""); ?>js/chat.js?v=1';
+    var scripts = document.getElementsByTagName('script');
+    for (var i = 0; i < scripts.length; i++) {
+        if (scripts[i].src && scripts[i].src.indexOf('/js/chat.js') !== -1) {
+            return;
+        }
+    }
+    var script = document.createElement('script');
+    script.src = src;
+    script.defer = true;
+    document.head.appendChild(script);
+})();
+</script>

--- a/chat.php
+++ b/chat.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * TravianZ Global Chat endpoint.
+ *
+ * This endpoint is intentionally separate from ajax.php because the browser
+ * polls chat frequently. Keeping it separate avoids filling AccessLogger with
+ * thousands of periodic chat requests.
+ */
+
+$autoloader_found = false;
+$autoprefix = '';
+
+for ($i = 0; $i < 5; $i++) {
+    $autoprefix = str_repeat('../', $i);
+    if (file_exists($autoprefix . 'autoloader.php')) {
+        $autoloader_found = true;
+        include_once $autoprefix . 'autoloader.php';
+        break;
+    }
+}
+
+if (!$autoloader_found) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => 0, 'error' => 'bootstrap']);
+    exit;
+}
+
+include_once $autoprefix . 'GameEngine/config.php';
+include_once $autoprefix . 'GameEngine/Database.php';
+include_once $autoprefix . 'GameEngine/Chat.php';
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
+$uid = isset($_SESSION['id_user']) ? (int) $_SESSION['id_user'] : 0;
+
+if ($uid <= 0) {
+    http_response_code(401);
+    echo json_encode(['ok' => 0, 'error' => 'unauthorized']);
+    exit;
+}
+
+if (!isset($database) || !is_object($database)) {
+    http_response_code(500);
+    echo json_encode(['ok' => 0, 'error' => 'database']);
+    exit;
+}
+
+$link = $database->return_link();
+
+if (!$link) {
+    http_response_code(500);
+    echo json_encode(['ok' => 0, 'error' => 'connection']);
+    exit;
+}
+
+$table = TB_PREFIX . 'chat';
+$username = (string) $database->getUserField($uid, 'username', '');
+
+if ($username === '') {
+    http_response_code(403);
+    echo json_encode(['ok' => 0, 'error' => 'user']);
+    exit;
+}
+
+$action = isset($_REQUEST['action']) ? (string) $_REQUEST['action'] : 'messages';
+
+if ($action === 'messages') {
+    $after = isset($_GET['after']) ? max(0, (int) $_GET['after']) : 0;
+
+    if ($after > 0) {
+        $stmt = mysqli_prepare(
+            $link,
+            "SELECT id_user AS uid, name AS username, date, msg AS message
+             FROM `" . $table . "`
+             WHERE id > ? AND alli = ''
+             ORDER BY id ASC
+             LIMIT 50"
+        );
+        if (!$stmt) {
+            http_response_code(500);
+            echo json_encode(['ok' => 0, 'error' => 'query']);
+            exit;
+        }
+        mysqli_stmt_bind_param($stmt, 'i', $after);
+    } else {
+        $stmt = mysqli_prepare(
+            $link,
+            "SELECT id, id_user AS uid, name AS username, date, msg AS message
+             FROM `" . $table . "`
+             WHERE alli = ''
+             ORDER BY id DESC
+             LIMIT 40"
+        );
+        if (!$stmt) {
+            http_response_code(500);
+            echo json_encode(['ok' => 0, 'error' => 'query']);
+            exit;
+        }
+    }
+
+    if (!mysqli_stmt_execute($stmt)) {
+        mysqli_stmt_close($stmt);
+        http_response_code(500);
+        echo json_encode(['ok' => 0, 'error' => 'execute']);
+        exit;
+    }
+
+    $result = mysqli_stmt_get_result($stmt);
+    if (!$result) {
+        mysqli_stmt_close($stmt);
+        http_response_code(500);
+        echo json_encode(['ok' => 0, 'error' => 'result']);
+        exit;
+    }
+
+    $messages = [];
+    while ($row = mysqli_fetch_assoc($result)) {
+        $messages[] = [
+            'id'       => isset($row['id']) ? (int) $row['id'] : 0,
+            'uid'      => (int) $row['uid'],
+            'username' => (string) $row['username'],
+            'message'  => (string) $row['message'],
+            'time'     => date('H:i', (int) $row['date']),
+        ];
+    }
+
+    mysqli_free_result($result);
+    mysqli_stmt_close($stmt);
+
+    if ($after === 0) {
+        $messages = array_reverse($messages);
+    }
+
+    // The legacy chat table uses an auto-increment id. Return the current
+    // maximum so the browser can continue polling from a stable cursor.
+    $latestResult = mysqli_query(
+        $link,
+        "SELECT MAX(id) AS latest_id FROM `" . $table . "` WHERE alli = ''"
+    );
+    $latestId = 0;
+    if ($latestResult) {
+        $latestRow = mysqli_fetch_assoc($latestResult);
+        $latestId = isset($latestRow['latest_id']) ? (int) $latestRow['latest_id'] : 0;
+        mysqli_free_result($latestResult);
+    }
+
+    echo json_encode([
+        'ok' => 1,
+        'uid' => $uid,
+        'messages' => $messages,
+        'latest_id' => $latestId,
+    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+if ($action === 'send') {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        http_response_code(405);
+        echo json_encode(['ok' => 0, 'error' => 'method']);
+        exit;
+    }
+
+    $now = microtime(true);
+    $lastSend = isset($_SESSION['tz_chat_last_send']) ? (float) $_SESSION['tz_chat_last_send'] : 0.0;
+
+    if (($now - $lastSend) < 1.0) {
+        http_response_code(429);
+        echo json_encode(['ok' => 0, 'error' => 'rate']);
+        exit;
+    }
+
+    $message = isset($_POST['message']) ? (string) $_POST['message'] : '';
+    $message = str_replace(["\r", "\n"], ' ', $message);
+    $message = trim($message);
+    $message = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u', '', $message);
+
+    if ($message === null) {
+        $message = '';
+    }
+
+    $length = function_exists('mb_strlen') ? mb_strlen($message, 'UTF-8') : strlen($message);
+
+    if ($length < 1) {
+        http_response_code(400);
+        echo json_encode(['ok' => 0, 'error' => 'empty']);
+        exit;
+    }
+
+    if ($length > 500) {
+        http_response_code(400);
+        echo json_encode(['ok' => 0, 'error' => 'length']);
+        exit;
+    }
+
+    $alliance = '';
+    $timestamp = time();
+
+    $stmt = mysqli_prepare(
+        $link,
+        "INSERT INTO `" . $table . "` (id_user, name, alli, date, msg)
+         VALUES (?, ?, ?, ?, ?)"
+    );
+
+    if (!$stmt) {
+        http_response_code(500);
+        echo json_encode(['ok' => 0, 'error' => 'prepare']);
+        exit;
+    }
+
+    mysqli_stmt_bind_param($stmt, 'issis', $uid, $username, $alliance, $timestamp, $message);
+    $ok = mysqli_stmt_execute($stmt);
+    $newId = $ok ? mysqli_insert_id($link) : 0;
+    mysqli_stmt_close($stmt);
+
+    if (!$ok) {
+        http_response_code(500);
+        echo json_encode(['ok' => 0, 'error' => 'insert']);
+        exit;
+    }
+
+    $_SESSION['tz_chat_last_send'] = $now;
+
+    echo json_encode([
+        'ok' => 1,
+        'id' => (int) $newId,
+    ]);
+    exit;
+}
+
+http_response_code(400);
+echo json_encode(['ok' => 0, 'error' => 'action']);

--- a/chat.php
+++ b/chat.php
@@ -29,7 +29,6 @@ if (!$autoloader_found) {
 
 include_once $autoprefix . 'GameEngine/config.php';
 include_once $autoprefix . 'GameEngine/Database.php';
-include_once $autoprefix . 'GameEngine/Chat.php';
 
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start();
@@ -78,17 +77,19 @@ if ($action === 'messages') {
     if ($after > 0) {
         $stmt = mysqli_prepare(
             $link,
-            "SELECT id_user AS uid, name AS username, date, msg AS message
+            "SELECT id, id_user AS uid, name AS username, date, msg AS message
              FROM `" . $table . "`
              WHERE id > ? AND alli = ''
              ORDER BY id ASC
              LIMIT 50"
         );
+
         if (!$stmt) {
             http_response_code(500);
             echo json_encode(['ok' => 0, 'error' => 'query']);
             exit;
         }
+
         mysqli_stmt_bind_param($stmt, 'i', $after);
     } else {
         $stmt = mysqli_prepare(
@@ -99,6 +100,7 @@ if ($action === 'messages') {
              ORDER BY id DESC
              LIMIT 40"
         );
+
         if (!$stmt) {
             http_response_code(500);
             echo json_encode(['ok' => 0, 'error' => 'query']);
@@ -114,6 +116,7 @@ if ($action === 'messages') {
     }
 
     $result = mysqli_stmt_get_result($stmt);
+
     if (!$result) {
         mysqli_stmt_close($stmt);
         http_response_code(500);
@@ -122,9 +125,10 @@ if ($action === 'messages') {
     }
 
     $messages = [];
+
     while ($row = mysqli_fetch_assoc($result)) {
         $messages[] = [
-            'id'       => isset($row['id']) ? (int) $row['id'] : 0,
+            'id'       => (int) $row['id'],
             'uid'      => (int) $row['uid'],
             'username' => (string) $row['username'],
             'message'  => (string) $row['message'],
@@ -139,13 +143,13 @@ if ($action === 'messages') {
         $messages = array_reverse($messages);
     }
 
-    // The legacy chat table uses an auto-increment id. Return the current
-    // maximum so the browser can continue polling from a stable cursor.
     $latestResult = mysqli_query(
         $link,
         "SELECT MAX(id) AS latest_id FROM `" . $table . "` WHERE alli = ''"
     );
+
     $latestId = 0;
+
     if ($latestResult) {
         $latestRow = mysqli_fetch_assoc($latestResult);
         $latestId = isset($latestRow['latest_id']) ? (int) $latestRow['latest_id'] : 0;

--- a/chat.php
+++ b/chat.php
@@ -190,6 +190,7 @@ if ($action === 'send') {
         $message = '';
     }
 
+    // The existing TravianZ chat table uses VARCHAR(255) for msg.
     $length = function_exists('mb_strlen') ? mb_strlen($message, 'UTF-8') : strlen($message);
 
     if ($length < 1) {
@@ -198,7 +199,7 @@ if ($action === 'send') {
         exit;
     }
 
-    if ($length > 500) {
+    if ($length > 255) {
         http_response_code(400);
         echo json_encode(['ok' => 0, 'error' => 'length']);
         exit;

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,0 +1,316 @@
+(function () {
+    'use strict';
+
+    function initChat() {
+        if (document.getElementById('tz-chat-root')) {
+            return;
+        }
+
+        var endpoint = 'chat.php';
+        var lastId = 0;
+        var initialized = false;
+        var opened = false;
+        var loading = false;
+        var pollingTimer = null;
+        var unread = 0;
+        var storageKey = 'tzChatLastSeen';
+
+        var style = document.createElement('style');
+        style.id = 'tz-chat-style';
+        style.textContent = [
+            '#tz-chat-root{position:fixed;right:18px;bottom:18px;z-index:99999;font-family:Arial,Helvetica,sans-serif;}',
+            '#tz-chat-toggle{position:relative;width:52px;height:52px;border:1px solid #6f543d;border-radius:50%;background:linear-gradient(#8f6a4a,#6b4e36);color:#fff;cursor:pointer;box-shadow:0 4px 12px rgba(0,0,0,.28);font-size:22px;font-weight:bold;}',
+            '#tz-chat-toggle:hover{filter:brightness(1.08);}',
+            '#tz-chat-badge{display:none;position:absolute;top:-4px;right:-2px;min-width:19px;height:19px;padding:0 5px;border-radius:10px;background:#b22a1f;color:#fff;font-size:11px;line-height:19px;text-align:center;box-sizing:border-box;border:2px solid #fff;}',
+            '#tz-chat-panel{display:none;width:330px;height:430px;margin-bottom:10px;overflow:hidden;background:#f4efe7;border:1px solid #6b513a;border-radius:6px;box-shadow:0 8px 28px rgba(0,0,0,.32);}',
+            '#tz-chat-root.tz-chat-open #tz-chat-panel{display:flex;flex-direction:column;}',
+            '#tz-chat-root.tz-chat-open #tz-chat-toggle{display:none;}',
+            '#tz-chat-head{height:42px;flex:0 0 42px;display:flex;align-items:center;justify-content:space-between;padding:0 10px 0 12px;box-sizing:border-box;background:linear-gradient(#876241,#684a33);color:#fff;border-bottom:1px solid #573c29;}',
+            '#tz-chat-title{font-size:13px;font-weight:bold;letter-spacing:.2px;}',
+            '#tz-chat-status{font-size:10px;font-weight:normal;opacity:.78;margin-left:6px;}',
+            '#tz-chat-close{width:27px;height:27px;border:0;background:transparent;color:#fff;cursor:pointer;font-size:21px;line-height:27px;padding:0;}',
+            '#tz-chat-messages{flex:1;overflow-y:auto;padding:10px 9px;background:linear-gradient(#f7f2ea,#eee7dc);box-sizing:border-box;}',
+            '.tz-chat-empty{padding:30px 18px;text-align:center;color:#8c8175;font-size:12px;}',
+            '.tz-chat-msg{display:flex;margin:0 0 8px;}',
+            '.tz-chat-msg.tz-chat-self{justify-content:flex-end;}',
+            '.tz-chat-bubble{max-width:82%;padding:6px 8px 5px;border:1px solid #d1c2af;border-radius:5px;background:#fffaf3;box-shadow:0 1px 2px rgba(0,0,0,.07);}',
+            '.tz-chat-self .tz-chat-bubble{background:#efe2d0;border-color:#c5ad92;}',
+            '.tz-chat-meta{font-size:10px;color:#806e5b;margin-bottom:3px;display:flex;gap:6px;align-items:baseline;}',
+            '.tz-chat-name{font-weight:bold;color:#5b4330;}',
+            '.tz-chat-time{opacity:.75;}',
+            '.tz-chat-text{font-size:12px;line-height:1.35;color:#40362f;word-break:break-word;white-space:pre-wrap;}',
+            '#tz-chat-form{display:flex;gap:6px;padding:8px;border-top:1px solid #c9b9a6;background:#e5dbcf;box-sizing:border-box;}',
+            '#tz-chat-input{flex:1;min-width:0;height:32px;border:1px solid #b7a58f;border-radius:4px;background:#fff;color:#3e342d;padding:0 8px;outline:none;font-size:12px;box-sizing:border-box;}',
+            '#tz-chat-input:focus{border-color:#806143;box-shadow:0 0 0 1px rgba(128,97,67,.14);}',
+            '#tz-chat-send{height:32px;padding:0 12px;border:1px solid #6c5139;border-radius:4px;background:linear-gradient(#9b744f,#755337);color:#fff;font-weight:bold;font-size:12px;cursor:pointer;}',
+            '#tz-chat-send:hover{filter:brightness(1.06);}',
+            '#tz-chat-send:disabled{opacity:.55;cursor:default;}',
+            '#tz-chat-error{display:none;padding:6px 9px;color:#8e2a20;background:#f7d8d3;border-top:1px solid #d59a92;font-size:11px;}',
+            '@media (max-width:600px){#tz-chat-root{right:10px;bottom:10px;}#tz-chat-panel{width:min(330px,calc(100vw - 20px));height:min(430px,calc(100vh - 80px));}}'
+        ].join('');
+        document.head.appendChild(style);
+
+        var root = document.createElement('div');
+        root.id = 'tz-chat-root';
+        root.innerHTML = [
+            '<div id="tz-chat-panel" role="dialog" aria-label="Global chat">',
+                '<div id="tz-chat-head">',
+                    '<div id="tz-chat-title">💬 Global Chat <span id="tz-chat-status">online</span></div>',
+                    '<button id="tz-chat-close" type="button" aria-label="Close">×</button>',
+                '</div>',
+                '<div id="tz-chat-messages"><div class="tz-chat-empty">Loading chat…</div></div>',
+                '<div id="tz-chat-error"></div>',
+                '<form id="tz-chat-form" autocomplete="off">',
+                    '<input id="tz-chat-input" type="text" maxlength="500" placeholder="Write a message…" aria-label="Message">',
+                    '<button id="tz-chat-send" type="submit">Send</button>',
+                '</form>',
+            '</div>',
+            '<button id="tz-chat-toggle" type="button" aria-label="Open chat">💬<span id="tz-chat-badge">0</span></button>'
+        ].join('');
+        document.body.appendChild(root);
+
+        var toggle = document.getElementById('tz-chat-toggle');
+        var closeButton = document.getElementById('tz-chat-close');
+        var messages = document.getElementById('tz-chat-messages');
+        var form = document.getElementById('tz-chat-form');
+        var input = document.getElementById('tz-chat-input');
+        var errorBox = document.getElementById('tz-chat-error');
+        var badge = document.getElementById('tz-chat-badge');
+
+        function setError(message) {
+            errorBox.textContent = message || '';
+            errorBox.style.display = message ? 'block' : 'none';
+        }
+
+        function scrollBottom() {
+            messages.scrollTop = messages.scrollHeight;
+        }
+
+        function showBadge(value) {
+            unread = Math.max(0, Number(value || 0));
+            if (unread > 0 && !opened) {
+                badge.style.display = 'block';
+                badge.textContent = unread > 99 ? '99+' : String(unread);
+            } else {
+                badge.style.display = 'none';
+            }
+        }
+
+        function markSeen() {
+            try {
+                localStorage.setItem(storageKey, String(lastId));
+            } catch (e) {}
+            showBadge(0);
+        }
+
+        function getStoredSeen() {
+            try {
+                var value = parseInt(localStorage.getItem(storageKey) || '0', 10);
+                return isFinite(value) ? value : 0;
+            } catch (e) {
+                return 0;
+            }
+        }
+
+        function appendMessage(item) {
+            var row = document.createElement('div');
+            row.className = 'tz-chat-msg' + (Number(item.uid) === Number(window.TZ_CHAT_UID || 0) ? ' tz-chat-self' : '');
+
+            var bubble = document.createElement('div');
+            bubble.className = 'tz-chat-bubble';
+
+            var meta = document.createElement('div');
+            meta.className = 'tz-chat-meta';
+
+            var name = document.createElement('span');
+            name.className = 'tz-chat-name';
+            name.textContent = item.username || 'Player';
+
+            var time = document.createElement('span');
+            time.className = 'tz-chat-time';
+            time.textContent = item.time || '';
+
+            var text = document.createElement('div');
+            text.className = 'tz-chat-text';
+            text.textContent = item.message || '';
+
+            meta.appendChild(name);
+            meta.appendChild(time);
+            bubble.appendChild(meta);
+            bubble.appendChild(text);
+            row.appendChild(bubble);
+            messages.appendChild(row);
+        }
+
+        function renderInitial(items) {
+            messages.innerHTML = '';
+            if (!items || !items.length) {
+                messages.innerHTML = '<div class="tz-chat-empty">No messages yet. Start the conversation.</div>';
+                return;
+            }
+            items.forEach(appendMessage);
+            scrollBottom();
+        }
+
+        function requestMessages(after) {
+            if (loading) {
+                return;
+            }
+            loading = true;
+            var url = endpoint + '?action=messages&after=' + encodeURIComponent(after || 0) + '&_=' + Date.now();
+
+            fetch(url, {
+                method: 'GET',
+                credentials: 'same-origin',
+                cache: 'no-store'
+            })
+            .then(function (response) {
+                return response.json().then(function (body) {
+                    return { status: response.status, body: body };
+                });
+            })
+            .then(function (result) {
+                var body = result.body || {};
+                if (!body.ok) {
+                    throw new Error(body.error || 'chat_error');
+                }
+
+                window.TZ_CHAT_UID = Number(body.uid || window.TZ_CHAT_UID || 0);
+                var items = body.messages || [];
+
+                if (!initialized && after === 0) {
+                    renderInitial(items);
+                    lastId = Number(body.latest_id || 0);
+                    initialized = true;
+
+                    var previousSeen = getStoredSeen();
+                    if (!previousSeen) {
+                        markSeen();
+                    } else if (lastId > previousSeen) {
+                        var initialUnread = items.filter(function (item) {
+                            return Number(item.id) > previousSeen;
+                        }).length;
+                        showBadge(initialUnread);
+                    }
+                } else {
+                    items.forEach(function (item) {
+                        appendMessage(item);
+                        lastId = Math.max(lastId, Number(item.id || 0));
+                    });
+
+                    if (items.length && !opened) {
+                        showBadge(unread + items.length);
+                    }
+
+                    if (items.length && opened) {
+                        scrollBottom();
+                        markSeen();
+                    }
+                }
+
+                if (opened) {
+                    markSeen();
+                }
+
+                setError('');
+            })
+            .catch(function () {
+                if (!initialized) {
+                    messages.innerHTML = '<div class="tz-chat-empty">Chat unavailable. Please refresh.</div>';
+                }
+                if (opened) {
+                    setError('Unable to reach the chat server.');
+                }
+            })
+            .finally(function () {
+                loading = false;
+            });
+        }
+
+        function startPolling() {
+            if (pollingTimer) {
+                return;
+            }
+            pollingTimer = window.setInterval(function () {
+                requestMessages(lastId);
+            }, 2500);
+        }
+
+        function openChat() {
+            opened = true;
+            root.classList.add('tz-chat-open');
+            showBadge(0);
+            requestMessages(lastId);
+            window.setTimeout(function () {
+                input.focus();
+                scrollBottom();
+            }, 0);
+        }
+
+        function closeChat() {
+            opened = false;
+            root.classList.remove('tz-chat-open');
+        }
+
+        toggle.addEventListener('click', openChat);
+        closeButton.addEventListener('click', closeChat);
+
+        form.addEventListener('submit', function (event) {
+            event.preventDefault();
+            setError('');
+
+            var message = input.value.trim();
+            if (!message) {
+                return;
+            }
+
+            var sendButton = document.getElementById('tz-chat-send');
+            sendButton.disabled = true;
+
+            var formData = new FormData();
+            formData.append('message', message);
+
+            fetch(endpoint + '?action=send', {
+                method: 'POST',
+                body: formData,
+                credentials: 'same-origin',
+                cache: 'no-store'
+            })
+            .then(function (response) {
+                return response.json().then(function (body) {
+                    return { status: response.status, body: body };
+                });
+            })
+            .then(function (result) {
+                var body = result.body || {};
+                if (!body.ok) {
+                    if (body.error === 'rate') {
+                        throw new Error('Please wait a moment before sending another message.');
+                    }
+                    if (body.error === 'length') {
+                        throw new Error('Message is too long (maximum 500 characters).');
+                    }
+                    throw new Error('Message could not be sent.');
+                }
+                input.value = '';
+                requestMessages(lastId);
+            })
+            .catch(function (error) {
+                setError(error.message || 'Message could not be sent.');
+            })
+            .finally(function () {
+                sendButton.disabled = false;
+                input.focus();
+            });
+        });
+
+        requestMessages(0);
+        startPolling();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initChat);
+    } else {
+        initChat();
+    }
+})();


### PR DESCRIPTION
## Global chat

Adds a lightweight floating global chat to logged-in TravianZ pages.

### Included
- Uses existing `chat` table; global messages are stored with empty `alli`.
- New `chat.php` endpoint with GET message polling and POST send.
- Prepared statements for chat queries/inserts.
- 255-character server-side message limit matching the existing schema.
- 1 message/second per-session anti-flood protection.
- Client-side DOM text rendering to prevent message HTML/JS execution.
- Incremental polling every 2.5 seconds instead of reloading full history.
- Unread badge stored per browser using localStorage.
- Travian-style brown/beige floating UI with mobile sizing.
- Loaded from the existing `Templates/natars.tpl`, so no change is required to the main header layout.
- Chat polling is kept out of `ajax.php` so AccessLogger is not flooded by frequent polling requests.

### Validation
- PHP syntax checked locally for the new endpoint.
- JavaScript syntax checked with Node.
- Diff compared against `master`; branch is 5 commits ahead and 0 behind.