### PR TITLE
Fix battle automation crash on invalid defender tribe

### DIFF
--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -3,7 +3,7 @@
 #################################################################################
 ##              -= YOU MAY NOT REMOVE OR CHANGE THIS NOTICE =-                 ##
 ## --------------------------------------------------------------------------- ##
-##  Filename       : Automation.php                      	                   ##
+##  Filename       : Automation.php                     	                   ##
 ##  Type           : Automation Function for entire TravianZ Game              ##
 ## --------------------------------------------------------------------------- ##
 ##  Developed by   : Mr.php , Advocaite , brainiacX , yi12345 , Shadow , ronix ##
@@ -15,10 +15,10 @@
 ##  Contact        : cata7007@gmail.com                                        ##
 ##  Project        : TravianZ                                                  ##
 ##  URLs:          : https://travianz.org                                      ##
-##  GitHub         : https://github.com/Shadowss/TravianZ                      ##
+##                 : https://github.com/Shadowss/TravianZ                      ##
 ## --------------------------------------------------------------------------- ##
-##  License        : TravianZ Project                                          ##
-##  Copyright      : TravianZ (c) 2010-2026. All rights reserved.              ##
+##  License:       TravianZ Project                                            ##
+##  Copyright:     TravianZ (c) 2010-2026. All rights reserved.                ##
 ## --------------------------------------------------------------------------- ##
 #################################################################################
 
@@ -48,7 +48,7 @@ if ( !defined('AUTOMATION_MANUAL_RUN') ) {
 /**
  * Automation.php presupunea ca apelantul a inclus deja config.php. Cand nu era
  * asa (de exemplu inclus din alt context), Database.php dadea eroare fatala:
- *   Undefined constant "SQL_SERVER"
+ *   Undefined constant \"SQL_SERVER\"
  *
  * Il incarcam noi daca lipseste. include_once nu-l aduce de doua ori.
  */
@@ -78,7 +78,7 @@ include_once("Building.php");
 include_once("Artifacts.php");
 
 // === Faza S2: clasa Automation este impartita in trait-uri pe domenii (GameEngine/Automation/) ===
-// Trait-urile sunt in namespace global, deci sunt incluse explicit (autoloaderul mapeaza doar App\).
+// Trait-urile sunt in namespace global, deci sunt incluse explicit (autoloaderul mapeaza doar App\\).
 include_once __DIR__ . '/Automation/AutomationVillageUpkeep.php';
 include_once __DIR__ . '/Automation/AutomationAccountMaintenance.php';
 include_once __DIR__ . '/Automation/AutomationBuildQueue.php';
@@ -150,13 +150,13 @@ class Automation {
         $methodsArrays = ["culturePoints", "updateHero", "clearDeleting", "buildComplete",
         				  "demolitionComplete", "marketComplete", "researchComplete",
         				  "trainingComplete", "healingComplete", "starvation", "celebrationComplete", "festivalComplete",
-        				  "sendUnitsComplete", "loyaltyRegeneration", "sendreinfunitsComplete",
+        				  "sendUnitsCompleteSafe", "loyaltyRegeneration", "sendreinfunitsComplete",
         				  "returnunitsComplete", "sendSettlersComplete", "spawnNatars",
         				  "spawnWWVillages", "spawnWWBuildingPlans", "activateArtifacts",
         				  "heroAdventureComplete",
         				  "cleanupOldData",
         				  "recordPlayerStatistics",
-					  "buildNatarsWonder"];
+        					  "buildNatarsWonder"];
         
         foreach($methodsArrays as $method){
         	$file = fopen($autoprefix."GameEngine/Prevention/".$method.".txt", "w");
@@ -181,6 +181,118 @@ class Automation {
         $this->regenerateOasisTroops();
         $this->medals();
         $this->artefactOfTheFool();
+    }
+
+    /**
+     * Process completed attacks only after removing battles whose village target
+     * no longer has a valid owner/tribe. This prevents invalid tribe math in
+     * AutomationBattleResolution (e.g. targettribe=0 -> unit range -9..0).
+     *
+     * The normal battle resolver remains untouched for valid targets.
+     */
+    private function sendUnitsCompleteSafe() {
+        global $database, $units;
+
+        $time = time();
+        $prefix = TB_PREFIX;
+
+        $q = "
+            SELECT
+                m.moveid,
+                m.`from`,
+                m.`to`,
+                m.ref,
+                m.endtime,
+                a.t1, a.t2, a.t3, a.t4, a.t5, a.t6, a.t7, a.t8, a.t9, a.t10, a.t11,
+                vf.owner AS attacker_owner,
+                vf.wref AS attacker_wref,
+                uf.tribe AS attacker_tribe
+            FROM {$prefix}movement m
+            INNER JOIN {$prefix}attacks a ON a.id = m.ref
+            LEFT JOIN {$prefix}vdata vt ON vt.wref = m.`to`
+            LEFT JOIN {$prefix}users ut ON ut.id = vt.owner
+            LEFT JOIN {$prefix}vdata vf ON vf.wref = m.`from`
+            LEFT JOIN {$prefix}users uf ON uf.id = vf.owner
+            WHERE m.proc = 0
+              AND m.sort_type = 3
+              AND a.attack_type != 2
+              AND m.endtime < {$time}
+              AND (vt.wref IS NULL OR vt.owner <= 0 OR ut.id IS NULL OR ut.tribe < 1 OR ut.tribe > 9)
+        ";
+
+        $result = $database->query_return($q);
+
+        if ($result && count($result)) {
+            foreach ($result as $invalidAttack) {
+                $moveid = (int)$invalidAttack['moveid'];
+                $from   = (int)$invalidAttack['from'];
+                $to     = (int)$invalidAttack['to'];
+                $owner  = (int)$invalidAttack['attacker_owner'];
+                $fromWref = (int)$invalidAttack['attacker_wref'];
+                $tribe  = (int)$invalidAttack['attacker_tribe'];
+
+                if ($moveid <= 0 || $from <= 0 || $to <= 0 || $owner <= 0 || $fromWref <= 0 || $tribe < 1 || $tribe > 9) {
+                    // No valid attacker context: consume the broken movement so cron
+                    // cannot loop forever on the same malformed battle record.
+                    $database->setMovementProc($moveid);
+                    continue;
+                }
+
+                // Claim this movement atomically. If another automation request got
+                // it first, do not create a duplicate return movement.
+                if (!$database->setMovementProc($moveid)) {
+                    continue;
+                }
+
+                $returningTroops = [
+                    't1' => (int)$invalidAttack['t1'],
+                    't2' => (int)$invalidAttack['t2'],
+                    't3' => (int)$invalidAttack['t3'],
+                    't4' => (int)$invalidAttack['t4'],
+                    't5' => (int)$invalidAttack['t5'],
+                    't6' => (int)$invalidAttack['t6'],
+                    't7' => (int)$invalidAttack['t7'],
+                    't8' => (int)$invalidAttack['t8'],
+                    't9' => (int)$invalidAttack['t9'],
+                    't10' => (int)$invalidAttack['t10'],
+                    't11' => (int)$invalidAttack['t11']
+                ];
+
+                $totalTroops = array_sum($returningTroops);
+                if ($totalTroops <= 0) {
+                    continue;
+                }
+
+                $troopsTime = $units->getWalkingTroopsTime(
+                    $fromWref,
+                    $to,
+                    $owner,
+                    $tribe,
+                    $returningTroops,
+                    1,
+                    't'
+                );
+
+                $endtime = $database->getArtifactsValueInfluence(
+                    $owner,
+                    $fromWref,
+                    2,
+                    $troopsTime
+                ) + $time;
+
+                $database->addMovement(
+                    4,
+                    $to,
+                    $fromWref,
+                    (int)$invalidAttack['ref'],
+                    $time,
+                    $endtime
+                );
+            }
+        }
+
+        // Process all remaining valid completed battles through the original engine.
+        $this->sendUnitsComplete();
     }
 
     /**

--- a/GameEngine/Automation.php
+++ b/GameEngine/Automation.php
@@ -3,7 +3,7 @@
 #################################################################################
 ##              -= YOU MAY NOT REMOVE OR CHANGE THIS NOTICE =-                 ##
 ## --------------------------------------------------------------------------- ##
-##  Filename       : Automation.php                     	                   ##
+##  Filename       : Automation.php                      	                   ##
 ##  Type           : Automation Function for entire TravianZ Game              ##
 ## --------------------------------------------------------------------------- ##
 ##  Developed by   : Mr.php , Advocaite , brainiacX , yi12345 , Shadow , ronix ##
@@ -17,8 +17,8 @@
 ##  URLs:          : https://travianz.org                                      ##
 ##                 : https://github.com/Shadowss/TravianZ                      ##
 ## --------------------------------------------------------------------------- ##
-##  License:       TravianZ Project                                            ##
-##  Copyright:     TravianZ (c) 2010-2026. All rights reserved.                ##
+##  License        : TravianZ Project                                          ##
+##  Copyright      : TravianZ (c) 2010-2026. All rights reserved.              ##
 ## --------------------------------------------------------------------------- ##
 #################################################################################
 
@@ -48,7 +48,7 @@ if ( !defined('AUTOMATION_MANUAL_RUN') ) {
 /**
  * Automation.php presupunea ca apelantul a inclus deja config.php. Cand nu era
  * asa (de exemplu inclus din alt context), Database.php dadea eroare fatala:
- *   Undefined constant \"SQL_SERVER\"
+ *   Undefined constant "SQL_SERVER"
  *
  * Il incarcam noi daca lipseste. include_once nu-l aduce de doua ori.
  */
@@ -78,7 +78,7 @@ include_once("Building.php");
 include_once("Artifacts.php");
 
 // === Faza S2: clasa Automation este impartita in trait-uri pe domenii (GameEngine/Automation/) ===
-// Trait-urile sunt in namespace global, deci sunt incluse explicit (autoloaderul mapeaza doar App\\).
+// Trait-urile sunt in namespace global, deci sunt incluse explicit (autoloaderul mapeaza doar App\).
 include_once __DIR__ . '/Automation/AutomationVillageUpkeep.php';
 include_once __DIR__ . '/Automation/AutomationAccountMaintenance.php';
 include_once __DIR__ . '/Automation/AutomationBuildQueue.php';
@@ -156,7 +156,7 @@ class Automation {
         				  "heroAdventureComplete",
         				  "cleanupOldData",
         				  "recordPlayerStatistics",
-        					  "buildNatarsWonder"];
+        				  "buildNatarsWonder"];
         
         foreach($methodsArrays as $method){
         	$file = fopen($autoprefix."GameEngine/Prevention/".$method.".txt", "w");
@@ -188,7 +188,8 @@ class Automation {
      * no longer has a valid owner/tribe. This prevents invalid tribe math in
      * AutomationBattleResolution (e.g. targettribe=0 -> unit range -9..0).
      *
-     * The normal battle resolver remains untouched for valid targets.
+     * Oasis targets are deliberately excluded because they do not have a vdata row
+     * and are handled by the normal oasis battle path.
      */
     private function sendUnitsCompleteSafe() {
         global $database, $units;
@@ -209,7 +210,7 @@ class Automation {
                 uf.tribe AS attacker_tribe
             FROM {$prefix}movement m
             INNER JOIN {$prefix}attacks a ON a.id = m.ref
-            LEFT JOIN {$prefix}vdata vt ON vt.wref = m.`to`
+            INNER JOIN {$prefix}vdata vt ON vt.wref = m.`to`
             LEFT JOIN {$prefix}users ut ON ut.id = vt.owner
             LEFT JOIN {$prefix}vdata vf ON vf.wref = m.`from`
             LEFT JOIN {$prefix}users uf ON uf.id = vf.owner
@@ -217,7 +218,7 @@ class Automation {
               AND m.sort_type = 3
               AND a.attack_type != 2
               AND m.endtime < {$time}
-              AND (vt.wref IS NULL OR vt.owner <= 0 OR ut.id IS NULL OR ut.tribe < 1 OR ut.tribe > 9)
+              AND (vt.owner <= 0 OR ut.id IS NULL OR ut.tribe < 1 OR ut.tribe > 9)
         ";
 
         $result = $database->query_return($q);
@@ -225,22 +226,21 @@ class Automation {
         if ($result && count($result)) {
             foreach ($result as $invalidAttack) {
                 $moveid = (int)$invalidAttack['moveid'];
-                $from   = (int)$invalidAttack['from'];
                 $to     = (int)$invalidAttack['to'];
                 $owner  = (int)$invalidAttack['attacker_owner'];
                 $fromWref = (int)$invalidAttack['attacker_wref'];
                 $tribe  = (int)$invalidAttack['attacker_tribe'];
 
-                if ($moveid <= 0 || $from <= 0 || $to <= 0 || $owner <= 0 || $fromWref <= 0 || $tribe < 1 || $tribe > 9) {
+                if ($moveid <= 0 || $to <= 0 || $owner <= 0 || $fromWref <= 0 || $tribe < 1 || $tribe > 9) {
                     // No valid attacker context: consume the broken movement so cron
                     // cannot loop forever on the same malformed battle record.
-                    $database->setMovementProc($moveid);
+                    $this->claimMovementRecord($moveid);
                     continue;
                 }
 
-                // Claim this movement atomically. If another automation request got
-                // it first, do not create a duplicate return movement.
-                if (!$database->setMovementProc($moveid)) {
+                // Atomically claim the incoming battle movement. If another process
+                // already consumed it, do not create a duplicate return movement.
+                if (!$this->claimMovementRecord($moveid)) {
                     continue;
                 }
 
@@ -263,6 +263,7 @@ class Automation {
                     continue;
                 }
 
+                $attackArrivalTime = (float)$invalidAttack['endtime'];
                 $troopsTime = $units->getWalkingTroopsTime(
                     $fromWref,
                     $to,
@@ -278,14 +279,14 @@ class Automation {
                     $fromWref,
                     2,
                     $troopsTime
-                ) + $time;
+                ) + $attackArrivalTime;
 
                 $database->addMovement(
                     4,
                     $to,
                     $fromWref,
                     (int)$invalidAttack['ref'],
-                    $time,
+                    $attackArrivalTime,
                     $endtime
                 );
             }


### PR DESCRIPTION
## Problem
Battle resolution could receive an invalid defender tribe (`0`/NULL) when an attack reaches a village that no longer has a valid owner. `applyOwnDefenceCasualties()` then calculated a unit range of `-9..0`, producing `u-9`, `u-8`, ... `u0` warnings and finally invalid SQL such as `u-9 = GREATEST(...)`.

## Fix
- Add a safe wrapper around `sendUnitsComplete()` in `GameEngine/Automation.php`.
- Before normal battle resolution, identify completed village attacks whose target still has a `vdata` row but no valid owner/tribe.
- Atomically consume those malformed battle movements using the existing `claimMovementRecord()` helper.
- Return the attacker's surviving troops to the source village instead of entering battle resolution.
- Leave normal village and oasis battles on the existing battle-resolution path.

## Result
Invalid defender records can no longer reach the casualty calculation with `targettribe=0`, preventing the `u-9..u0` warnings and MariaDB syntax fatal.

The change is isolated to the automation dispatch layer; valid battles continue to use the existing resolver unchanged.